### PR TITLE
docs: regenerate alef API references

### DIFF
--- a/docs/reference/api-c.md
+++ b/docs/reference/api-c.md
@@ -135,6 +135,20 @@ bool literllm_unregister_custom_provider(const char* name);
 
 ### Types
 
+#### LiterllmApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `const char*` | — | Message |
+| `error_type` | `const char*` | — | Error type |
+| `param` | `const char**` | `NULL` | Param |
+| `code` | `const char**` | `NULL` | Code |
+
+
+---
+
 #### LiterllmAssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ bool literllm_unregister_custom_provider(const char* name);
 |-------|------|---------|-------------|
 | `data` | `const char*` | — | Base64-encoded audio data. |
 | `format` | `const char*` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### LiterllmBatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### literllm_create_batch()
+
+Create a new batch job.
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_create_batch(LiterllmCreateBatchRequest req);
+```
+
+###### literllm_retrieve_batch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_retrieve_batch(const char* batch_id);
+```
+
+###### literllm_list_batches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```c
+LiterllmBatchListResponse literllm_list_batches(LiterllmBatchListQuery query);
+```
+
+###### literllm_cancel_batch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_cancel_batch(const char* batch_id);
+```
 
 
 ---
@@ -215,6 +278,22 @@ bool literllm_unregister_custom_provider(const char* name);
 | `system_fingerprint` | `const char**` | `NULL` | System fingerprint |
 | `service_tier` | `const char**` | `NULL` | Service tier |
 
+##### Methods
+
+###### literllm_estimated_cost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `NULL` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```c
+double* literllm_estimated_cost();
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ bool literllm_unregister_custom_provider(const char* name);
 | `index` | `uint32_t` | — | Index |
 | `message` | `LiterllmAssistantMessage` | — | Message (assistant message) |
 | `finish_reason` | `LiterllmFinishReason*` | `NULL` | Finish reason (finish reason) |
+
+
+---
+
+#### LiterllmClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `const char*` | — | API key for authentication (stored as a secret). |
+| `base_url` | `const char**` | `NULL` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `uint64_t` | — | Request timeout. |
+| `max_retries` | `uint32_t` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `LiterllmCredentialProvider*` | `NULL` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### literllm_headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```c
+void** literllm_headers();
+```
+
+###### literllm_fmt()
+
+**Signature:**
+
+```c
+LiterllmUnknown literllm_fmt(LiterllmFormatter f);
+```
+
+
+---
+
+#### LiterllmClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### literllm_from_env()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_from_env();
+```
+
+###### literllm_load_env()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_load_env(bool enabled);
+```
+
+###### literllm_base_url()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_base_url(const char* url);
+```
+
+###### literllm_timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_timeout(uint64_t timeout);
+```
+
+###### literllm_max_retries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_max_retries(uint32_t retries);
+```
+
+###### literllm_credential_provider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_credential_provider(LiterllmCredentialProvider provider);
+```
+
+###### literllm_header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_header(const char* key, const char* value);
+```
+
+###### literllm_cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_cache(LiterllmCacheConfig config);
+```
+
+###### literllm_cache_store()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_cache_store(LiterllmCacheStore store);
+```
+
+###### literllm_budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_budget(LiterllmBudgetConfig config);
+```
+
+###### literllm_hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_hook(LiterllmLlmHook hook);
+```
+
+###### literllm_hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_hooks(LiterllmLlmHook* hooks);
+```
+
+###### literllm_cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_cooldown(uint64_t duration);
+```
+
+###### literllm_rate_limit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_rate_limit(LiterllmRateLimitConfig config);
+```
+
+###### literllm_health_check()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_health_check(uint64_t interval);
+```
+
+###### literllm_cost_tracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_cost_tracking(bool enabled);
+```
+
+###### literllm_tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_tracing(bool enabled);
+```
+
+###### literllm_build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```c
+LiterllmClientConfig literllm_build();
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### literllm_new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `NULL` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```c
+LiterllmDefaultClient literllm_new(LiterllmClientConfig config, const char* model_hint);
+```
+
 ###### literllm_chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ LiterllmChatCompletionResponse literllm_chat(LiterllmChatCompletionRequest req);
 **Signature:**
 
 ```c
-const char* literllm_chat_stream(LiterllmChatCompletionRequest req);
+LiterllmBoxStream literllm_chat_stream(LiterllmChatCompletionRequest req);
 ```
 
 ###### literllm_embed()
@@ -358,6 +742,14 @@ LiterllmModelsListResponse literllm_list_models();
 
 ```c
 LiterllmImagesResponse literllm_image_generate(LiterllmCreateImageRequest req);
+```
+
+###### literllm_speech()
+
+**Signature:**
+
+```c
+const uint8_t* literllm_speech(LiterllmCreateSpeechRequest req);
 ```
 
 ###### literllm_transcribe()
@@ -390,6 +782,182 @@ LiterllmRerankResponse literllm_rerank(LiterllmRerankRequest req);
 
 ```c
 LiterllmSearchResponse literllm_search(LiterllmSearchRequest req);
+```
+
+###### literllm_ocr()
+
+**Signature:**
+
+```c
+LiterllmOcrResponse literllm_ocr(LiterllmOcrRequest req);
+```
+
+###### literllm_chat_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_chat_raw(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_chat_stream_raw()
+
+**Signature:**
+
+```c
+LiterllmRawStreamExchange literllm_chat_stream_raw(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_embed_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_embed_raw(LiterllmEmbeddingRequest req);
+```
+
+###### literllm_image_generate_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_image_generate_raw(LiterllmCreateImageRequest req);
+```
+
+###### literllm_transcribe_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_transcribe_raw(LiterllmCreateTranscriptionRequest req);
+```
+
+###### literllm_moderate_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_moderate_raw(LiterllmModerationRequest req);
+```
+
+###### literllm_rerank_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_rerank_raw(LiterllmRerankRequest req);
+```
+
+###### literllm_search_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_search_raw(LiterllmSearchRequest req);
+```
+
+###### literllm_ocr_raw()
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_ocr_raw(LiterllmOcrRequest req);
+```
+
+###### literllm_create_file()
+
+**Signature:**
+
+```c
+LiterllmFileObject literllm_create_file(LiterllmCreateFileRequest req);
+```
+
+###### literllm_retrieve_file()
+
+**Signature:**
+
+```c
+LiterllmFileObject literllm_retrieve_file(const char* file_id);
+```
+
+###### literllm_delete_file()
+
+**Signature:**
+
+```c
+LiterllmDeleteResponse literllm_delete_file(const char* file_id);
+```
+
+###### literllm_list_files()
+
+**Signature:**
+
+```c
+LiterllmFileListResponse literllm_list_files(LiterllmFileListQuery query);
+```
+
+###### literllm_file_content()
+
+**Signature:**
+
+```c
+const uint8_t* literllm_file_content(const char* file_id);
+```
+
+###### literllm_create_batch()
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_create_batch(LiterllmCreateBatchRequest req);
+```
+
+###### literllm_retrieve_batch()
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_retrieve_batch(const char* batch_id);
+```
+
+###### literllm_list_batches()
+
+**Signature:**
+
+```c
+LiterllmBatchListResponse literllm_list_batches(LiterllmBatchListQuery query);
+```
+
+###### literllm_cancel_batch()
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_cancel_batch(const char* batch_id);
+```
+
+###### literllm_create_response()
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_create_response(LiterllmCreateResponseRequest req);
+```
+
+###### literllm_retrieve_response()
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_retrieve_response(const char* id);
+```
+
+###### literllm_cancel_response()
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_cancel_response(const char* id);
 ```
 
 
@@ -447,6 +1015,247 @@ LiterllmSearchResponse literllm_search(LiterllmSearchRequest req);
 | `data` | `LiterllmEmbeddingObject*` | — | Data |
 | `model` | `const char*` | — | Model |
 | `usage` | `LiterllmUsage*` | `NULL` | Usage (usage) |
+
+##### Methods
+
+###### literllm_estimated_cost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `NULL` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```c
+double* literllm_estimated_cost();
+```
+
+
+---
+
+#### LiterllmErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `LiterllmApiError` | — | Error (api error) |
+
+
+---
+
+#### LiterllmFileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `double*` | `NULL` | Global limit |
+| `model_limits` | `void**` | `NULL` | Model limits |
+| `enforcement` | `const char**` | `NULL` | Enforcement |
+
+
+---
+
+#### LiterllmFileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `uintptr_t*` | `NULL` | Maximum entries |
+| `ttl_seconds` | `uint64_t*` | `NULL` | Ttl seconds |
+| `backend` | `const char**` | `NULL` | Backend |
+| `backend_config` | `void**` | `NULL` | Backend config |
+
+
+---
+
+#### LiterllmFileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### literllm_create_file()
+
+Upload a file.
+
+**Signature:**
+
+```c
+LiterllmFileObject literllm_create_file(LiterllmCreateFileRequest req);
+```
+
+###### literllm_retrieve_file()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```c
+LiterllmFileObject literllm_retrieve_file(const char* file_id);
+```
+
+###### literllm_delete_file()
+
+Delete a file.
+
+**Signature:**
+
+```c
+LiterllmDeleteResponse literllm_delete_file(const char* file_id);
+```
+
+###### literllm_list_files()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```c
+LiterllmFileListResponse literllm_list_files(LiterllmFileListQuery query);
+```
+
+###### literllm_file_content()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```c
+const uint8_t* literllm_file_content(const char* file_id);
+```
+
+
+---
+
+#### LiterllmFileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `const char**` | `NULL` | Api key |
+| `base_url` | `const char**` | `NULL` | Base url |
+| `model_hint` | `const char**` | `NULL` | Model hint |
+| `timeout_secs` | `uint64_t*` | `NULL` | Timeout secs |
+| `max_retries` | `uint32_t*` | `NULL` | Maximum retries |
+| `extra_headers` | `void**` | `NULL` | Extra headers |
+| `cache` | `LiterllmFileCacheConfig*` | `NULL` | Cache (file cache config) |
+| `budget` | `LiterllmFileBudgetConfig*` | `NULL` | Budget (file budget config) |
+| `cooldown_secs` | `uint64_t*` | `NULL` | Cooldown secs |
+| `rate_limit` | `LiterllmFileRateLimitConfig*` | `NULL` | Rate limit (file rate limit config) |
+| `health_check_secs` | `uint64_t*` | `NULL` | Health check secs |
+| `cost_tracking` | `bool*` | `NULL` | Cost tracking |
+| `tracing` | `bool*` | `NULL` | Tracing |
+| `providers` | `LiterllmFileProviderConfig**` | `NULL` | Providers |
+
+##### Methods
+
+###### literllm_from_toml_file()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```c
+LiterllmFileConfig literllm_from_toml_file(LiterllmPath path);
+```
+
+###### literllm_from_toml_str()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```c
+LiterllmFileConfig literllm_from_toml_str(const char* s);
+```
+
+###### literllm_discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```c
+LiterllmFileConfig* literllm_discover();
+```
+
+###### literllm_into_builder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```c
+LiterllmClientConfigBuilder literllm_into_builder();
+```
+
+###### literllm_providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```c
+LiterllmFileProviderConfig* literllm_providers();
+```
+
+
+---
+
+#### LiterllmFileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `const char*` | — | The name |
+| `base_url` | `const char*` | — | Base url |
+| `auth_header` | `const char**` | `NULL` | Auth header |
+| `model_prefixes` | `const char**` | — | Model prefixes |
+
+
+---
+
+#### LiterllmFileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `uint32_t*` | `NULL` | Rpm |
+| `tpm` | `uint64_t*` | `NULL` | Tpm |
+| `window_seconds` | `uint64_t*` | `NULL` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterllmLiterLlmError
+
+##### Methods
+
+###### literllm_is_transient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```c
+bool literllm_is_transient();
+```
+
+###### literllm_error_type()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```c
+const char* literllm_error_type();
+```
+
+###### literllm_from_status()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```c
+LiterllmLiterLlmError literllm_from_status(uint16_t status, const char* body, uint64_t retry_after);
+```
+
+
+---
+
+#### LiterllmLlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### literllm_chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```c
+LiterllmChatCompletionResponse literllm_chat(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_chat_stream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```c
+LiterllmBoxStream literllm_chat_stream(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```c
+LiterllmEmbeddingResponse literllm_embed(LiterllmEmbeddingRequest req);
+```
+
+###### literllm_list_models()
+
+List available models.
+
+**Signature:**
+
+```c
+LiterllmModelsListResponse literllm_list_models();
+```
+
+###### literllm_image_generate()
+
+Generate an image.
+
+**Signature:**
+
+```c
+LiterllmImagesResponse literllm_image_generate(LiterllmCreateImageRequest req);
+```
+
+###### literllm_speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```c
+const uint8_t* literllm_speech(LiterllmCreateSpeechRequest req);
+```
+
+###### literllm_transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```c
+LiterllmTranscriptionResponse literllm_transcribe(LiterllmCreateTranscriptionRequest req);
+```
+
+###### literllm_moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```c
+LiterllmModerationResponse literllm_moderate(LiterllmModerationRequest req);
+```
+
+###### literllm_rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```c
+LiterllmRerankResponse literllm_rerank(LiterllmRerankRequest req);
+```
+
+###### literllm_search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```c
+LiterllmSearchResponse literllm_search(LiterllmSearchRequest req);
+```
+
+###### literllm_ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```c
+LiterllmOcrResponse literllm_ocr(LiterllmOcrRequest req);
+```
+
+
+---
+
+#### LiterllmLlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### literllm_chat_raw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_chat_raw(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_chat_stream_raw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```c
+LiterllmRawStreamExchange literllm_chat_stream_raw(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_embed_raw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_embed_raw(LiterllmEmbeddingRequest req);
+```
+
+###### literllm_image_generate_raw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_image_generate_raw(LiterllmCreateImageRequest req);
+```
+
+###### literllm_transcribe_raw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_transcribe_raw(LiterllmCreateTranscriptionRequest req);
+```
+
+###### literllm_moderate_raw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_moderate_raw(LiterllmModerationRequest req);
+```
+
+###### literllm_rerank_raw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_rerank_raw(LiterllmRerankRequest req);
+```
+
+###### literllm_search_raw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_search_raw(LiterllmSearchRequest req);
+```
+
+###### literllm_ocr_raw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```c
+LiterllmRawExchange literllm_ocr_raw(LiterllmOcrRequest req);
+```
+
+
+---
+
+#### LiterllmManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### literllm_new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```c
+LiterllmManagedClient literllm_new(LiterllmClientConfig config, const char* model_hint);
+```
+
+###### literllm_inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```c
+LiterllmDefaultClient literllm_inner();
+```
+
+###### literllm_budget_state()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```c
+LiterllmBudgetState* literllm_budget_state();
+```
+
+###### literllm_has_middleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```c
+bool literllm_has_middleware();
+```
+
+###### literllm_chat()
+
+**Signature:**
+
+```c
+LiterllmChatCompletionResponse literllm_chat(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_chat_stream()
+
+**Signature:**
+
+```c
+LiterllmBoxStream literllm_chat_stream(LiterllmChatCompletionRequest req);
+```
+
+###### literllm_embed()
+
+**Signature:**
+
+```c
+LiterllmEmbeddingResponse literllm_embed(LiterllmEmbeddingRequest req);
+```
+
+###### literllm_list_models()
+
+**Signature:**
+
+```c
+LiterllmModelsListResponse literllm_list_models();
+```
+
+###### literllm_image_generate()
+
+**Signature:**
+
+```c
+LiterllmImagesResponse literllm_image_generate(LiterllmCreateImageRequest req);
+```
+
+###### literllm_speech()
+
+**Signature:**
+
+```c
+const uint8_t* literllm_speech(LiterllmCreateSpeechRequest req);
+```
+
+###### literllm_transcribe()
+
+**Signature:**
+
+```c
+LiterllmTranscriptionResponse literllm_transcribe(LiterllmCreateTranscriptionRequest req);
+```
+
+###### literllm_moderate()
+
+**Signature:**
+
+```c
+LiterllmModerationResponse literllm_moderate(LiterllmModerationRequest req);
+```
+
+###### literllm_rerank()
+
+**Signature:**
+
+```c
+LiterllmRerankResponse literllm_rerank(LiterllmRerankRequest req);
+```
+
+###### literllm_search()
+
+**Signature:**
+
+```c
+LiterllmSearchResponse literllm_search(LiterllmSearchRequest req);
+```
+
+###### literllm_ocr()
+
+**Signature:**
+
+```c
+LiterllmOcrResponse literllm_ocr(LiterllmOcrRequest req);
+```
+
+###### literllm_create_file()
+
+**Signature:**
+
+```c
+LiterllmFileObject literllm_create_file(LiterllmCreateFileRequest req);
+```
+
+###### literllm_retrieve_file()
+
+**Signature:**
+
+```c
+LiterllmFileObject literllm_retrieve_file(const char* file_id);
+```
+
+###### literllm_delete_file()
+
+**Signature:**
+
+```c
+LiterllmDeleteResponse literllm_delete_file(const char* file_id);
+```
+
+###### literllm_list_files()
+
+**Signature:**
+
+```c
+LiterllmFileListResponse literllm_list_files(LiterllmFileListQuery query);
+```
+
+###### literllm_file_content()
+
+**Signature:**
+
+```c
+const uint8_t* literllm_file_content(const char* file_id);
+```
+
+###### literllm_create_batch()
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_create_batch(LiterllmCreateBatchRequest req);
+```
+
+###### literllm_retrieve_batch()
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_retrieve_batch(const char* batch_id);
+```
+
+###### literllm_list_batches()
+
+**Signature:**
+
+```c
+LiterllmBatchListResponse literllm_list_batches(LiterllmBatchListQuery query);
+```
+
+###### literllm_cancel_batch()
+
+**Signature:**
+
+```c
+LiterllmBatchObject literllm_cancel_batch(const char* batch_id);
+```
+
+###### literllm_create_response()
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_create_response(LiterllmCreateResponseRequest req);
+```
+
+###### literllm_retrieve_response()
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_retrieve_response(const char* id);
+```
+
+###### literllm_cancel_response()
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_cancel_response(const char* id);
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `const char*` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `LiterllmOcrDocument` | — | The document to process. |
-| `pages` | `uint32_t**` | `NULL` | Specific pages to process (1-indexed). `NULL` means all pages. |
+| `pages` | `uint32_t**` | `NULL` | Specific pages to process (1-indexed). `None` means all pages. |
 | `include_image_base64` | `bool*` | `NULL` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `const char*` | — | Text |
+
+
+---
+
+#### LiterllmResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### literllm_create_response()
+
+Create a new response.
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_create_response(LiterllmCreateResponseRequest req);
+```
+
+###### literllm_retrieve_response()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_retrieve_response(const char* id);
+```
+
+###### literllm_cancel_response()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```c
+LiterllmResponseObject literllm_cancel_response(const char* id);
+```
 
 
 ---
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-csharp.md
+++ b/docs/reference/api-csharp.md
@@ -135,6 +135,20 @@ public static bool UnregisterCustomProvider(string name)
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Message` | `string` | — | Message |
+| `ErrorType` | `string` | — | Error type |
+| `Param` | `string?` | `null` | Param |
+| `Code` | `string?` | `null` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ public static bool UnregisterCustomProvider(string name)
 |-------|------|---------|-------------|
 | `Data` | `string` | — | Base64-encoded audio data. |
 | `Format` | `string` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### CreateBatch()
+
+Create a new batch job.
+
+**Signature:**
+
+```csharp
+public BatchObject CreateBatch(CreateBatchRequest req)
+```
+
+###### RetrieveBatch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```csharp
+public BatchObject RetrieveBatch(string batchId)
+```
+
+###### ListBatches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```csharp
+public BatchListResponse ListBatches(BatchListQuery query)
+```
+
+###### CancelBatch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```csharp
+public BatchObject CancelBatch(string batchId)
+```
 
 
 ---
@@ -215,6 +278,22 @@ public static bool UnregisterCustomProvider(string name)
 | `SystemFingerprint` | `string?` | `null` | System fingerprint |
 | `ServiceTier` | `string?` | `null` | Service tier |
 
+##### Methods
+
+###### EstimatedCost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```csharp
+public double? EstimatedCost()
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ public static bool UnregisterCustomProvider(string name)
 | `Index` | `uint` | — | Index |
 | `Message` | `AssistantMessage` | — | Message (assistant message) |
 | `FinishReason` | `FinishReason?` | `null` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ApiKey` | `string` | — | API key for authentication (stored as a secret). |
+| `BaseUrl` | `string?` | `null` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `Timeout` | `TimeSpan` | — | Request timeout. |
+| `MaxRetries` | `uint` | — | Maximum number of retries on 429 / 5xx responses. |
+| `CredentialProvider` | `CredentialProvider?` | `null` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `LoadEnv` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### Headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```csharp
+public List<(string, string)> Headers()
+```
+
+###### Fmt()
+
+**Signature:**
+
+```csharp
+public Unknown Fmt(Formatter f)
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### FromEnv()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder FromEnv()
+```
+
+###### LoadEnv()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder LoadEnv(bool enabled)
+```
+
+###### BaseUrl()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder BaseUrl(string url)
+```
+
+###### Timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Timeout(TimeSpan timeout)
+```
+
+###### MaxRetries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder MaxRetries(uint retries)
+```
+
+###### CredentialProvider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder CredentialProvider(CredentialProvider provider)
+```
+
+###### Header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Header(string key, string value)
+```
+
+###### Cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Cache(CacheConfig config)
+```
+
+###### CacheStore()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder CacheStore(CacheStore store)
+```
+
+###### Budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Budget(BudgetConfig config)
+```
+
+###### Hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Hook(LlmHook hook)
+```
+
+###### Hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Hooks(List<LlmHook> hooks)
+```
+
+###### Cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Cooldown(TimeSpan duration)
+```
+
+###### RateLimit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder RateLimit(RateLimitConfig config)
+```
+
+###### HealthCheck()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder HealthCheck(TimeSpan interval)
+```
+
+###### CostTracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder CostTracking(bool enabled)
+```
+
+###### Tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder Tracing(bool enabled)
+```
+
+###### Build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```csharp
+public ClientConfig Build()
+```
 
 
 ---
@@ -320,12 +683,33 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### New()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `null` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```csharp
+public DefaultClient New(ClientConfig config, string modelHint)
+```
+
 ###### Chat()
 
 **Signature:**
 
 ```csharp
-public async Task<ChatCompletionResponse> ChatAsync(ChatCompletionRequest req)
+public ChatCompletionResponse Chat(ChatCompletionRequest req)
 ```
 
 ###### ChatStream()
@@ -333,7 +717,7 @@ public async Task<ChatCompletionResponse> ChatAsync(ChatCompletionRequest req)
 **Signature:**
 
 ```csharp
-public async Task<string> ChatStreamAsync(ChatCompletionRequest req)
+public BoxStream ChatStream(ChatCompletionRequest req)
 ```
 
 ###### Embed()
@@ -341,7 +725,7 @@ public async Task<string> ChatStreamAsync(ChatCompletionRequest req)
 **Signature:**
 
 ```csharp
-public async Task<EmbeddingResponse> EmbedAsync(EmbeddingRequest req)
+public EmbeddingResponse Embed(EmbeddingRequest req)
 ```
 
 ###### ListModels()
@@ -349,7 +733,7 @@ public async Task<EmbeddingResponse> EmbedAsync(EmbeddingRequest req)
 **Signature:**
 
 ```csharp
-public async Task<ModelsListResponse> ListModelsAsync()
+public ModelsListResponse ListModels()
 ```
 
 ###### ImageGenerate()
@@ -357,7 +741,15 @@ public async Task<ModelsListResponse> ListModelsAsync()
 **Signature:**
 
 ```csharp
-public async Task<ImagesResponse> ImageGenerateAsync(CreateImageRequest req)
+public ImagesResponse ImageGenerate(CreateImageRequest req)
+```
+
+###### Speech()
+
+**Signature:**
+
+```csharp
+public byte[] Speech(CreateSpeechRequest req)
 ```
 
 ###### Transcribe()
@@ -365,7 +757,7 @@ public async Task<ImagesResponse> ImageGenerateAsync(CreateImageRequest req)
 **Signature:**
 
 ```csharp
-public async Task<TranscriptionResponse> TranscribeAsync(CreateTranscriptionRequest req)
+public TranscriptionResponse Transcribe(CreateTranscriptionRequest req)
 ```
 
 ###### Moderate()
@@ -373,7 +765,7 @@ public async Task<TranscriptionResponse> TranscribeAsync(CreateTranscriptionRequ
 **Signature:**
 
 ```csharp
-public async Task<ModerationResponse> ModerateAsync(ModerationRequest req)
+public ModerationResponse Moderate(ModerationRequest req)
 ```
 
 ###### Rerank()
@@ -381,7 +773,7 @@ public async Task<ModerationResponse> ModerateAsync(ModerationRequest req)
 **Signature:**
 
 ```csharp
-public async Task<RerankResponse> RerankAsync(RerankRequest req)
+public RerankResponse Rerank(RerankRequest req)
 ```
 
 ###### Search()
@@ -389,7 +781,183 @@ public async Task<RerankResponse> RerankAsync(RerankRequest req)
 **Signature:**
 
 ```csharp
-public async Task<SearchResponse> SearchAsync(SearchRequest req)
+public SearchResponse Search(SearchRequest req)
+```
+
+###### Ocr()
+
+**Signature:**
+
+```csharp
+public OcrResponse Ocr(OcrRequest req)
+```
+
+###### ChatRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange ChatRaw(ChatCompletionRequest req)
+```
+
+###### ChatStreamRaw()
+
+**Signature:**
+
+```csharp
+public RawStreamExchange ChatStreamRaw(ChatCompletionRequest req)
+```
+
+###### EmbedRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange EmbedRaw(EmbeddingRequest req)
+```
+
+###### ImageGenerateRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange ImageGenerateRaw(CreateImageRequest req)
+```
+
+###### TranscribeRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange TranscribeRaw(CreateTranscriptionRequest req)
+```
+
+###### ModerateRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange ModerateRaw(ModerationRequest req)
+```
+
+###### RerankRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange RerankRaw(RerankRequest req)
+```
+
+###### SearchRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange SearchRaw(SearchRequest req)
+```
+
+###### OcrRaw()
+
+**Signature:**
+
+```csharp
+public RawExchange OcrRaw(OcrRequest req)
+```
+
+###### CreateFile()
+
+**Signature:**
+
+```csharp
+public FileObject CreateFile(CreateFileRequest req)
+```
+
+###### RetrieveFile()
+
+**Signature:**
+
+```csharp
+public FileObject RetrieveFile(string fileId)
+```
+
+###### DeleteFile()
+
+**Signature:**
+
+```csharp
+public DeleteResponse DeleteFile(string fileId)
+```
+
+###### ListFiles()
+
+**Signature:**
+
+```csharp
+public FileListResponse ListFiles(FileListQuery query)
+```
+
+###### FileContent()
+
+**Signature:**
+
+```csharp
+public byte[] FileContent(string fileId)
+```
+
+###### CreateBatch()
+
+**Signature:**
+
+```csharp
+public BatchObject CreateBatch(CreateBatchRequest req)
+```
+
+###### RetrieveBatch()
+
+**Signature:**
+
+```csharp
+public BatchObject RetrieveBatch(string batchId)
+```
+
+###### ListBatches()
+
+**Signature:**
+
+```csharp
+public BatchListResponse ListBatches(BatchListQuery query)
+```
+
+###### CancelBatch()
+
+**Signature:**
+
+```csharp
+public BatchObject CancelBatch(string batchId)
+```
+
+###### CreateResponse()
+
+**Signature:**
+
+```csharp
+public ResponseObject CreateResponse(CreateResponseRequest req)
+```
+
+###### RetrieveResponse()
+
+**Signature:**
+
+```csharp
+public ResponseObject RetrieveResponse(string id)
+```
+
+###### CancelResponse()
+
+**Signature:**
+
+```csharp
+public ResponseObject CancelResponse(string id)
 ```
 
 
@@ -447,6 +1015,247 @@ public async Task<SearchResponse> SearchAsync(SearchRequest req)
 | `Data` | `List<EmbeddingObject>` | — | Data |
 | `Model` | `string` | — | Model |
 | `Usage` | `Usage?` | `null` | Usage (usage) |
+
+##### Methods
+
+###### EstimatedCost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```csharp
+public double? EstimatedCost()
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `GlobalLimit` | `double?` | `null` | Global limit |
+| `ModelLimits` | `Dictionary<string, double>?` | `null` | Model limits |
+| `Enforcement` | `string?` | `null` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `MaxEntries` | `nuint?` | `null` | Maximum entries |
+| `TtlSeconds` | `ulong?` | `null` | Ttl seconds |
+| `Backend` | `string?` | `null` | Backend |
+| `BackendConfig` | `Dictionary<string, string>?` | `null` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### CreateFile()
+
+Upload a file.
+
+**Signature:**
+
+```csharp
+public FileObject CreateFile(CreateFileRequest req)
+```
+
+###### RetrieveFile()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```csharp
+public FileObject RetrieveFile(string fileId)
+```
+
+###### DeleteFile()
+
+Delete a file.
+
+**Signature:**
+
+```csharp
+public DeleteResponse DeleteFile(string fileId)
+```
+
+###### ListFiles()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```csharp
+public FileListResponse ListFiles(FileListQuery query)
+```
+
+###### FileContent()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```csharp
+public byte[] FileContent(string fileId)
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ApiKey` | `string?` | `null` | Api key |
+| `BaseUrl` | `string?` | `null` | Base url |
+| `ModelHint` | `string?` | `null` | Model hint |
+| `TimeoutSecs` | `ulong?` | `null` | Timeout secs |
+| `MaxRetries` | `uint?` | `null` | Maximum retries |
+| `ExtraHeaders` | `Dictionary<string, string>?` | `null` | Extra headers |
+| `Cache` | `FileCacheConfig?` | `null` | Cache (file cache config) |
+| `Budget` | `FileBudgetConfig?` | `null` | Budget (file budget config) |
+| `CooldownSecs` | `ulong?` | `null` | Cooldown secs |
+| `RateLimit` | `FileRateLimitConfig?` | `null` | Rate limit (file rate limit config) |
+| `HealthCheckSecs` | `ulong?` | `null` | Health check secs |
+| `CostTracking` | `bool?` | `null` | Cost tracking |
+| `Tracing` | `bool?` | `null` | Tracing |
+| `Providers` | `List<FileProviderConfig>?` | `null` | Providers |
+
+##### Methods
+
+###### FromTomlFile()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```csharp
+public FileConfig FromTomlFile(Path path)
+```
+
+###### FromTomlStr()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```csharp
+public FileConfig FromTomlStr(string s)
+```
+
+###### Discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```csharp
+public FileConfig? Discover()
+```
+
+###### IntoBuilder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```csharp
+public ClientConfigBuilder IntoBuilder()
+```
+
+###### Providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```csharp
+public List<FileProviderConfig> Providers()
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Name` | `string` | — | The name |
+| `BaseUrl` | `string` | — | Base url |
+| `AuthHeader` | `string?` | `null` | Auth header |
+| `ModelPrefixes` | `List<string>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Rpm` | `uint?` | `null` | Rpm |
+| `Tpm` | `ulong?` | `null` | Tpm |
+| `WindowSeconds` | `ulong?` | `null` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### IsTransient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```csharp
+public bool IsTransient()
+```
+
+###### ErrorType()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```csharp
+public string ErrorType()
+```
+
+###### FromStatus()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```csharp
+public LiterLlmError FromStatus(ushort status, string body, TimeSpan retryAfter)
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### Chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```csharp
+public ChatCompletionResponse Chat(ChatCompletionRequest req)
+```
+
+###### ChatStream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```csharp
+public BoxStream ChatStream(ChatCompletionRequest req)
+```
+
+###### Embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```csharp
+public EmbeddingResponse Embed(EmbeddingRequest req)
+```
+
+###### ListModels()
+
+List available models.
+
+**Signature:**
+
+```csharp
+public ModelsListResponse ListModels()
+```
+
+###### ImageGenerate()
+
+Generate an image.
+
+**Signature:**
+
+```csharp
+public ImagesResponse ImageGenerate(CreateImageRequest req)
+```
+
+###### Speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```csharp
+public byte[] Speech(CreateSpeechRequest req)
+```
+
+###### Transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```csharp
+public TranscriptionResponse Transcribe(CreateTranscriptionRequest req)
+```
+
+###### Moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```csharp
+public ModerationResponse Moderate(ModerationRequest req)
+```
+
+###### Rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```csharp
+public RerankResponse Rerank(RerankRequest req)
+```
+
+###### Search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```csharp
+public SearchResponse Search(SearchRequest req)
+```
+
+###### Ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```csharp
+public OcrResponse Ocr(OcrRequest req)
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### ChatRaw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```csharp
+public RawExchange ChatRaw(ChatCompletionRequest req)
+```
+
+###### ChatStreamRaw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```csharp
+public RawStreamExchange ChatStreamRaw(ChatCompletionRequest req)
+```
+
+###### EmbedRaw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange EmbedRaw(EmbeddingRequest req)
+```
+
+###### ImageGenerateRaw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange ImageGenerateRaw(CreateImageRequest req)
+```
+
+###### TranscribeRaw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange TranscribeRaw(CreateTranscriptionRequest req)
+```
+
+###### ModerateRaw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange ModerateRaw(ModerationRequest req)
+```
+
+###### RerankRaw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange RerankRaw(RerankRequest req)
+```
+
+###### SearchRaw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange SearchRaw(SearchRequest req)
+```
+
+###### OcrRaw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```csharp
+public RawExchange OcrRaw(OcrRequest req)
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### New()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```csharp
+public ManagedClient New(ClientConfig config, string modelHint)
+```
+
+###### Inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```csharp
+public DefaultClient Inner()
+```
+
+###### BudgetState()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```csharp
+public BudgetState? BudgetState()
+```
+
+###### HasMiddleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```csharp
+public bool HasMiddleware()
+```
+
+###### Chat()
+
+**Signature:**
+
+```csharp
+public ChatCompletionResponse Chat(ChatCompletionRequest req)
+```
+
+###### ChatStream()
+
+**Signature:**
+
+```csharp
+public BoxStream ChatStream(ChatCompletionRequest req)
+```
+
+###### Embed()
+
+**Signature:**
+
+```csharp
+public EmbeddingResponse Embed(EmbeddingRequest req)
+```
+
+###### ListModels()
+
+**Signature:**
+
+```csharp
+public ModelsListResponse ListModels()
+```
+
+###### ImageGenerate()
+
+**Signature:**
+
+```csharp
+public ImagesResponse ImageGenerate(CreateImageRequest req)
+```
+
+###### Speech()
+
+**Signature:**
+
+```csharp
+public byte[] Speech(CreateSpeechRequest req)
+```
+
+###### Transcribe()
+
+**Signature:**
+
+```csharp
+public TranscriptionResponse Transcribe(CreateTranscriptionRequest req)
+```
+
+###### Moderate()
+
+**Signature:**
+
+```csharp
+public ModerationResponse Moderate(ModerationRequest req)
+```
+
+###### Rerank()
+
+**Signature:**
+
+```csharp
+public RerankResponse Rerank(RerankRequest req)
+```
+
+###### Search()
+
+**Signature:**
+
+```csharp
+public SearchResponse Search(SearchRequest req)
+```
+
+###### Ocr()
+
+**Signature:**
+
+```csharp
+public OcrResponse Ocr(OcrRequest req)
+```
+
+###### CreateFile()
+
+**Signature:**
+
+```csharp
+public FileObject CreateFile(CreateFileRequest req)
+```
+
+###### RetrieveFile()
+
+**Signature:**
+
+```csharp
+public FileObject RetrieveFile(string fileId)
+```
+
+###### DeleteFile()
+
+**Signature:**
+
+```csharp
+public DeleteResponse DeleteFile(string fileId)
+```
+
+###### ListFiles()
+
+**Signature:**
+
+```csharp
+public FileListResponse ListFiles(FileListQuery query)
+```
+
+###### FileContent()
+
+**Signature:**
+
+```csharp
+public byte[] FileContent(string fileId)
+```
+
+###### CreateBatch()
+
+**Signature:**
+
+```csharp
+public BatchObject CreateBatch(CreateBatchRequest req)
+```
+
+###### RetrieveBatch()
+
+**Signature:**
+
+```csharp
+public BatchObject RetrieveBatch(string batchId)
+```
+
+###### ListBatches()
+
+**Signature:**
+
+```csharp
+public BatchListResponse ListBatches(BatchListQuery query)
+```
+
+###### CancelBatch()
+
+**Signature:**
+
+```csharp
+public BatchObject CancelBatch(string batchId)
+```
+
+###### CreateResponse()
+
+**Signature:**
+
+```csharp
+public ResponseObject CreateResponse(CreateResponseRequest req)
+```
+
+###### RetrieveResponse()
+
+**Signature:**
+
+```csharp
+public ResponseObject RetrieveResponse(string id)
+```
+
+###### CancelResponse()
+
+**Signature:**
+
+```csharp
+public ResponseObject CancelResponse(string id)
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `Model` | `string` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `Document` | `OcrDocument` | — | The document to process. |
-| `Pages` | `List<uint>?` | `null` | Specific pages to process (1-indexed). `null` means all pages. |
+| `Pages` | `List<uint>?` | `null` | Specific pages to process (1-indexed). `None` means all pages. |
 | `IncludeImageBase64` | `bool?` | `null` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `Text` | `string` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### CreateResponse()
+
+Create a new response.
+
+**Signature:**
+
+```csharp
+public ResponseObject CreateResponse(CreateResponseRequest req)
+```
+
+###### RetrieveResponse()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```csharp
+public ResponseObject RetrieveResponse(string id)
+```
+
+###### CancelResponse()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```csharp
+public ResponseObject CancelResponse(string id)
+```
 
 
 ---
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-elixir.md
+++ b/docs/reference/api-elixir.md
@@ -139,6 +139,20 @@ def unregister_custom_provider(name)
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `String.t()` | — | Message |
+| `error_type` | `String.t()` | — | Error type |
+| `param` | `String.t() | nil` | `nil` | Param |
+| `code` | `String.t() | nil` | `nil` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -158,6 +172,55 @@ def unregister_custom_provider(name)
 |-------|------|---------|-------------|
 | `data` | `String.t()` | — | Base64-encoded audio data. |
 | `format` | `String.t()` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Functions
+
+###### create_batch()
+
+Create a new batch job.
+
+**Signature:**
+
+```elixir
+def create_batch(req)
+```
+
+###### retrieve_batch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```elixir
+def retrieve_batch(batch_id)
+```
+
+###### list_batches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```elixir
+def list_batches(query)
+```
+
+###### cancel_batch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```elixir
+def cancel_batch(batch_id)
+```
 
 
 ---
@@ -219,6 +282,22 @@ def unregister_custom_provider(name)
 | `system_fingerprint` | `String.t() | nil` | `nil` | System fingerprint |
 | `service_tier` | `String.t() | nil` | `nil` | Service tier |
 
+##### Functions
+
+###### estimated_cost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `nil` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```elixir
+def estimated_cost()
+```
+
 
 ---
 
@@ -239,6 +318,290 @@ def unregister_custom_provider(name)
 | `index` | `integer()` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finish_reason` | `FinishReason | nil` | `nil` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String.t()` | — | API key for authentication (stored as a secret). |
+| `base_url` | `String.t() | nil` | `nil` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `integer()` | — | Request timeout. |
+| `max_retries` | `integer()` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `CredentialProvider | nil` | `nil` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `boolean()` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Functions
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```elixir
+def headers()
+```
+
+###### fmt()
+
+**Signature:**
+
+```elixir
+def fmt(f)
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Functions
+
+###### from_env()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```elixir
+def from_env()
+```
+
+###### load_env()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```elixir
+def load_env(enabled)
+```
+
+###### base_url()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```elixir
+def base_url(url)
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```elixir
+def timeout(timeout)
+```
+
+###### max_retries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```elixir
+def max_retries(retries)
+```
+
+###### credential_provider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```elixir
+def credential_provider(provider)
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```elixir
+def header(key, value)
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```elixir
+def cache(config)
+```
+
+###### cache_store()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```elixir
+def cache_store(store)
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```elixir
+def budget(config)
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```elixir
+def hook(hook)
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```elixir
+def hooks(hooks)
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```elixir
+def cooldown(duration)
+```
+
+###### rate_limit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```elixir
+def rate_limit(config)
+```
+
+###### health_check()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```elixir
+def health_check(interval)
+```
+
+###### cost_tracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```elixir
+def cost_tracking(enabled)
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```elixir
+def tracing(enabled)
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```elixir
+def build()
+```
 
 
 ---
@@ -324,6 +687,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Functions
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `nil` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```elixir
+def new(config, model_hint)
+```
+
 ###### chat()
 
 **Signature:**
@@ -364,6 +748,14 @@ def list_models()
 def image_generate(req)
 ```
 
+###### speech()
+
+**Signature:**
+
+```elixir
+def speech(req)
+```
+
 ###### transcribe()
 
 **Signature:**
@@ -394,6 +786,182 @@ def rerank(req)
 
 ```elixir
 def search(req)
+```
+
+###### ocr()
+
+**Signature:**
+
+```elixir
+def ocr(req)
+```
+
+###### chat_raw()
+
+**Signature:**
+
+```elixir
+def chat_raw(req)
+```
+
+###### chat_stream_raw()
+
+**Signature:**
+
+```elixir
+def chat_stream_raw(req)
+```
+
+###### embed_raw()
+
+**Signature:**
+
+```elixir
+def embed_raw(req)
+```
+
+###### image_generate_raw()
+
+**Signature:**
+
+```elixir
+def image_generate_raw(req)
+```
+
+###### transcribe_raw()
+
+**Signature:**
+
+```elixir
+def transcribe_raw(req)
+```
+
+###### moderate_raw()
+
+**Signature:**
+
+```elixir
+def moderate_raw(req)
+```
+
+###### rerank_raw()
+
+**Signature:**
+
+```elixir
+def rerank_raw(req)
+```
+
+###### search_raw()
+
+**Signature:**
+
+```elixir
+def search_raw(req)
+```
+
+###### ocr_raw()
+
+**Signature:**
+
+```elixir
+def ocr_raw(req)
+```
+
+###### create_file()
+
+**Signature:**
+
+```elixir
+def create_file(req)
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```elixir
+def retrieve_file(file_id)
+```
+
+###### delete_file()
+
+**Signature:**
+
+```elixir
+def delete_file(file_id)
+```
+
+###### list_files()
+
+**Signature:**
+
+```elixir
+def list_files(query)
+```
+
+###### file_content()
+
+**Signature:**
+
+```elixir
+def file_content(file_id)
+```
+
+###### create_batch()
+
+**Signature:**
+
+```elixir
+def create_batch(req)
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```elixir
+def retrieve_batch(batch_id)
+```
+
+###### list_batches()
+
+**Signature:**
+
+```elixir
+def list_batches(query)
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```elixir
+def cancel_batch(batch_id)
+```
+
+###### create_response()
+
+**Signature:**
+
+```elixir
+def create_response(req)
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```elixir
+def retrieve_response(id)
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```elixir
+def cancel_response(id)
 ```
 
 
@@ -451,6 +1019,247 @@ def search(req)
 | `data` | `list(EmbeddingObject)` | — | Data |
 | `model` | `String.t()` | — | Model |
 | `usage` | `Usage | nil` | `nil` | Usage (usage) |
+
+##### Functions
+
+###### estimated_cost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `nil` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```elixir
+def estimated_cost()
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `float() | nil` | `nil` | Global limit |
+| `model_limits` | `map() | nil` | `nil` | Model limits |
+| `enforcement` | `String.t() | nil` | `nil` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `integer() | nil` | `nil` | Maximum entries |
+| `ttl_seconds` | `integer() | nil` | `nil` | Ttl seconds |
+| `backend` | `String.t() | nil` | `nil` | Backend |
+| `backend_config` | `map() | nil` | `nil` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Functions
+
+###### create_file()
+
+Upload a file.
+
+**Signature:**
+
+```elixir
+def create_file(req)
+```
+
+###### retrieve_file()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```elixir
+def retrieve_file(file_id)
+```
+
+###### delete_file()
+
+Delete a file.
+
+**Signature:**
+
+```elixir
+def delete_file(file_id)
+```
+
+###### list_files()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```elixir
+def list_files(query)
+```
+
+###### file_content()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```elixir
+def file_content(file_id)
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String.t() | nil` | `nil` | Api key |
+| `base_url` | `String.t() | nil` | `nil` | Base url |
+| `model_hint` | `String.t() | nil` | `nil` | Model hint |
+| `timeout_secs` | `integer() | nil` | `nil` | Timeout secs |
+| `max_retries` | `integer() | nil` | `nil` | Maximum retries |
+| `extra_headers` | `map() | nil` | `nil` | Extra headers |
+| `cache` | `FileCacheConfig | nil` | `nil` | Cache (file cache config) |
+| `budget` | `FileBudgetConfig | nil` | `nil` | Budget (file budget config) |
+| `cooldown_secs` | `integer() | nil` | `nil` | Cooldown secs |
+| `rate_limit` | `FileRateLimitConfig | nil` | `nil` | Rate limit (file rate limit config) |
+| `health_check_secs` | `integer() | nil` | `nil` | Health check secs |
+| `cost_tracking` | `boolean() | nil` | `nil` | Cost tracking |
+| `tracing` | `boolean() | nil` | `nil` | Tracing |
+| `providers` | `list(FileProviderConfig) | nil` | `nil` | Providers |
+
+##### Functions
+
+###### from_toml_file()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```elixir
+def from_toml_file(path)
+```
+
+###### from_toml_str()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```elixir
+def from_toml_str(s)
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```elixir
+def discover()
+```
+
+###### into_builder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```elixir
+def into_builder()
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```elixir
+def providers()
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `String.t()` | — | The name |
+| `base_url` | `String.t()` | — | Base url |
+| `auth_header` | `String.t() | nil` | `nil` | Auth header |
+| `model_prefixes` | `list(String.t())` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `integer() | nil` | `nil` | Rpm |
+| `tpm` | `integer() | nil` | `nil` | Tpm |
+| `window_seconds` | `integer() | nil` | `nil` | Window seconds |
 
 
 ---
@@ -537,6 +1346,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Functions
+
+###### is_transient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```elixir
+def is_transient()
+```
+
+###### error_type()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```elixir
+def error_type()
+```
+
+###### from_status()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```elixir
+def from_status(status, body, retry_after)
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Functions
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```elixir
+def chat(req)
+```
+
+###### chat_stream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```elixir
+def chat_stream(req)
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```elixir
+def embed(req)
+```
+
+###### list_models()
+
+List available models.
+
+**Signature:**
+
+```elixir
+def list_models()
+```
+
+###### image_generate()
+
+Generate an image.
+
+**Signature:**
+
+```elixir
+def image_generate(req)
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```elixir
+def speech(req)
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```elixir
+def transcribe(req)
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```elixir
+def moderate(req)
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```elixir
+def rerank(req)
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```elixir
+def search(req)
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```elixir
+def ocr(req)
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Functions
+
+###### chat_raw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```elixir
+def chat_raw(req)
+```
+
+###### chat_stream_raw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```elixir
+def chat_stream_raw(req)
+```
+
+###### embed_raw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def embed_raw(req)
+```
+
+###### image_generate_raw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def image_generate_raw(req)
+```
+
+###### transcribe_raw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def transcribe_raw(req)
+```
+
+###### moderate_raw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def moderate_raw(req)
+```
+
+###### rerank_raw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def rerank_raw(req)
+```
+
+###### search_raw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def search_raw(req)
+```
+
+###### ocr_raw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```elixir
+def ocr_raw(req)
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Functions
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```elixir
+def new(config, model_hint)
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```elixir
+def inner()
+```
+
+###### budget_state()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```elixir
+def budget_state()
+```
+
+###### has_middleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```elixir
+def has_middleware()
+```
+
+###### chat()
+
+**Signature:**
+
+```elixir
+def chat(req)
+```
+
+###### chat_stream()
+
+**Signature:**
+
+```elixir
+def chat_stream(req)
+```
+
+###### embed()
+
+**Signature:**
+
+```elixir
+def embed(req)
+```
+
+###### list_models()
+
+**Signature:**
+
+```elixir
+def list_models()
+```
+
+###### image_generate()
+
+**Signature:**
+
+```elixir
+def image_generate(req)
+```
+
+###### speech()
+
+**Signature:**
+
+```elixir
+def speech(req)
+```
+
+###### transcribe()
+
+**Signature:**
+
+```elixir
+def transcribe(req)
+```
+
+###### moderate()
+
+**Signature:**
+
+```elixir
+def moderate(req)
+```
+
+###### rerank()
+
+**Signature:**
+
+```elixir
+def rerank(req)
+```
+
+###### search()
+
+**Signature:**
+
+```elixir
+def search(req)
+```
+
+###### ocr()
+
+**Signature:**
+
+```elixir
+def ocr(req)
+```
+
+###### create_file()
+
+**Signature:**
+
+```elixir
+def create_file(req)
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```elixir
+def retrieve_file(file_id)
+```
+
+###### delete_file()
+
+**Signature:**
+
+```elixir
+def delete_file(file_id)
+```
+
+###### list_files()
+
+**Signature:**
+
+```elixir
+def list_files(query)
+```
+
+###### file_content()
+
+**Signature:**
+
+```elixir
+def file_content(file_id)
+```
+
+###### create_batch()
+
+**Signature:**
+
+```elixir
+def create_batch(req)
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```elixir
+def retrieve_batch(batch_id)
+```
+
+###### list_batches()
+
+**Signature:**
+
+```elixir
+def list_batches(query)
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```elixir
+def cancel_batch(batch_id)
+```
+
+###### create_response()
+
+**Signature:**
+
+```elixir
+def create_response(req)
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```elixir
+def retrieve_response(id)
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```elixir
+def cancel_response(id)
+```
 
 
 ---
@@ -677,7 +2022,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `String.t()` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `OcrDocument` | — | The document to process. |
-| `pages` | `list(integer()) | nil` | `nil` | Specific pages to process (1-indexed). `nil` means all pages. |
+| `pages` | `list(integer()) | nil` | `nil` | Specific pages to process (1-indexed). `None` means all pages. |
 | `include_image_base64` | `boolean() | nil` | `nil` | Whether to include base64-encoded images of each page. |
 
 
@@ -756,6 +2101,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `String.t()` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Functions
+
+###### create_response()
+
+Create a new response.
+
+**Signature:**
+
+```elixir
+def create_response(req)
+```
+
+###### retrieve_response()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```elixir
+def retrieve_response(id)
+```
+
+###### cancel_response()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```elixir
+def cancel_response(id)
+```
 
 
 ---
@@ -1191,3 +2575,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-go.md
+++ b/docs/reference/api-go.md
@@ -135,6 +135,20 @@ func UnregisterCustomProvider(name string) (bool, error)
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Message` | `string` | — | Message |
+| `ErrorType` | `string` | — | Error type |
+| `Param` | `*string` | `nil` | Param |
+| `Code` | `*string` | `nil` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ func UnregisterCustomProvider(name string) (bool, error)
 |-------|------|---------|-------------|
 | `Data` | `string` | — | Base64-encoded audio data. |
 | `Format` | `string` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### CreateBatch()
+
+Create a new batch job.
+
+**Signature:**
+
+```go
+func (o *BatchClient) CreateBatch(req CreateBatchRequest) (BatchObject, error)
+```
+
+###### RetrieveBatch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```go
+func (o *BatchClient) RetrieveBatch(batchId string) (BatchObject, error)
+```
+
+###### ListBatches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```go
+func (o *BatchClient) ListBatches(query BatchListQuery) (BatchListResponse, error)
+```
+
+###### CancelBatch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```go
+func (o *BatchClient) CancelBatch(batchId string) (BatchObject, error)
+```
 
 
 ---
@@ -215,6 +278,22 @@ func UnregisterCustomProvider(name string) (bool, error)
 | `SystemFingerprint` | `*string` | `nil` | System fingerprint |
 | `ServiceTier` | `*string` | `nil` | Service tier |
 
+##### Methods
+
+###### EstimatedCost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `nil` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```go
+func (o *ChatCompletionResponse) EstimatedCost() *float64
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ func UnregisterCustomProvider(name string) (bool, error)
 | `Index` | `uint32` | — | Index |
 | `Message` | `AssistantMessage` | — | Message (assistant message) |
 | `FinishReason` | `*FinishReason` | `nil` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ApiKey` | `string` | — | API key for authentication (stored as a secret). |
+| `BaseUrl` | `*string` | `nil` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `Timeout` | `time.Duration` | — | Request timeout. |
+| `MaxRetries` | `uint32` | — | Maximum number of retries on 429 / 5xx responses. |
+| `CredentialProvider` | `*CredentialProvider` | `nil` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `LoadEnv` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### Headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```go
+func (o *ClientConfig) Headers() [](string, string)
+```
+
+###### Fmt()
+
+**Signature:**
+
+```go
+func (o *ClientConfig) Fmt(f Formatter) Unknown
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### FromEnv()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) FromEnv() ClientConfigBuilder
+```
+
+###### LoadEnv()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) LoadEnv(enabled bool) ClientConfigBuilder
+```
+
+###### BaseUrl()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) BaseUrl(url string) ClientConfigBuilder
+```
+
+###### Timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Timeout(timeout time.Duration) ClientConfigBuilder
+```
+
+###### MaxRetries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) MaxRetries(retries uint32) ClientConfigBuilder
+```
+
+###### CredentialProvider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) CredentialProvider(provider CredentialProvider) ClientConfigBuilder
+```
+
+###### Header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Header(key string, value string) (ClientConfigBuilder, error)
+```
+
+###### Cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Cache(config CacheConfig) ClientConfigBuilder
+```
+
+###### CacheStore()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) CacheStore(store CacheStore) ClientConfigBuilder
+```
+
+###### Budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Budget(config BudgetConfig) ClientConfigBuilder
+```
+
+###### Hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Hook(hook LlmHook) ClientConfigBuilder
+```
+
+###### Hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Hooks(hooks []LlmHook) ClientConfigBuilder
+```
+
+###### Cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Cooldown(duration time.Duration) ClientConfigBuilder
+```
+
+###### RateLimit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) RateLimit(config RateLimitConfig) ClientConfigBuilder
+```
+
+###### HealthCheck()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) HealthCheck(interval time.Duration) ClientConfigBuilder
+```
+
+###### CostTracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) CostTracking(enabled bool) ClientConfigBuilder
+```
+
+###### Tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Tracing(enabled bool) ClientConfigBuilder
+```
+
+###### Build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```go
+func (o *ClientConfigBuilder) Build() ClientConfig
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### New()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `nil` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```go
+func (o *DefaultClient) New(config ClientConfig, modelHint string) (DefaultClient, error)
+```
+
 ###### Chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ func (o *DefaultClient) Chat(req ChatCompletionRequest) (ChatCompletionResponse,
 **Signature:**
 
 ```go
-func (o *DefaultClient) ChatStream(req ChatCompletionRequest) (string, error)
+func (o *DefaultClient) ChatStream(req ChatCompletionRequest) (BoxStream, error)
 ```
 
 ###### Embed()
@@ -358,6 +742,14 @@ func (o *DefaultClient) ListModels() (ModelsListResponse, error)
 
 ```go
 func (o *DefaultClient) ImageGenerate(req CreateImageRequest) (ImagesResponse, error)
+```
+
+###### Speech()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) Speech(req CreateSpeechRequest) ([]byte, error)
 ```
 
 ###### Transcribe()
@@ -390,6 +782,182 @@ func (o *DefaultClient) Rerank(req RerankRequest) (RerankResponse, error)
 
 ```go
 func (o *DefaultClient) Search(req SearchRequest) (SearchResponse, error)
+```
+
+###### Ocr()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) Ocr(req OcrRequest) (OcrResponse, error)
+```
+
+###### ChatRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) ChatRaw(req ChatCompletionRequest) (RawExchange, error)
+```
+
+###### ChatStreamRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) ChatStreamRaw(req ChatCompletionRequest) (RawStreamExchange, error)
+```
+
+###### EmbedRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) EmbedRaw(req EmbeddingRequest) (RawExchange, error)
+```
+
+###### ImageGenerateRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) ImageGenerateRaw(req CreateImageRequest) (RawExchange, error)
+```
+
+###### TranscribeRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) TranscribeRaw(req CreateTranscriptionRequest) (RawExchange, error)
+```
+
+###### ModerateRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) ModerateRaw(req ModerationRequest) (RawExchange, error)
+```
+
+###### RerankRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) RerankRaw(req RerankRequest) (RawExchange, error)
+```
+
+###### SearchRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) SearchRaw(req SearchRequest) (RawExchange, error)
+```
+
+###### OcrRaw()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) OcrRaw(req OcrRequest) (RawExchange, error)
+```
+
+###### CreateFile()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) CreateFile(req CreateFileRequest) (FileObject, error)
+```
+
+###### RetrieveFile()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) RetrieveFile(fileId string) (FileObject, error)
+```
+
+###### DeleteFile()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) DeleteFile(fileId string) (DeleteResponse, error)
+```
+
+###### ListFiles()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) ListFiles(query FileListQuery) (FileListResponse, error)
+```
+
+###### FileContent()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) FileContent(fileId string) ([]byte, error)
+```
+
+###### CreateBatch()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) CreateBatch(req CreateBatchRequest) (BatchObject, error)
+```
+
+###### RetrieveBatch()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) RetrieveBatch(batchId string) (BatchObject, error)
+```
+
+###### ListBatches()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) ListBatches(query BatchListQuery) (BatchListResponse, error)
+```
+
+###### CancelBatch()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) CancelBatch(batchId string) (BatchObject, error)
+```
+
+###### CreateResponse()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) CreateResponse(req CreateResponseRequest) (ResponseObject, error)
+```
+
+###### RetrieveResponse()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) RetrieveResponse(id string) (ResponseObject, error)
+```
+
+###### CancelResponse()
+
+**Signature:**
+
+```go
+func (o *DefaultClient) CancelResponse(id string) (ResponseObject, error)
 ```
 
 
@@ -447,6 +1015,247 @@ func (o *DefaultClient) Search(req SearchRequest) (SearchResponse, error)
 | `Data` | `[]EmbeddingObject` | — | Data |
 | `Model` | `string` | — | Model |
 | `Usage` | `*Usage` | `nil` | Usage (usage) |
+
+##### Methods
+
+###### EstimatedCost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `nil` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```go
+func (o *EmbeddingResponse) EstimatedCost() *float64
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `GlobalLimit` | `*float64` | `nil` | Global limit |
+| `ModelLimits` | `*map[string]float64` | `nil` | Model limits |
+| `Enforcement` | `*string` | `nil` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `MaxEntries` | `*int` | `nil` | Maximum entries |
+| `TtlSeconds` | `*uint64` | `nil` | Ttl seconds |
+| `Backend` | `*string` | `nil` | Backend |
+| `BackendConfig` | `*map[string]string` | `nil` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### CreateFile()
+
+Upload a file.
+
+**Signature:**
+
+```go
+func (o *FileClient) CreateFile(req CreateFileRequest) (FileObject, error)
+```
+
+###### RetrieveFile()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```go
+func (o *FileClient) RetrieveFile(fileId string) (FileObject, error)
+```
+
+###### DeleteFile()
+
+Delete a file.
+
+**Signature:**
+
+```go
+func (o *FileClient) DeleteFile(fileId string) (DeleteResponse, error)
+```
+
+###### ListFiles()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```go
+func (o *FileClient) ListFiles(query FileListQuery) (FileListResponse, error)
+```
+
+###### FileContent()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```go
+func (o *FileClient) FileContent(fileId string) ([]byte, error)
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `ApiKey` | `*string` | `nil` | Api key |
+| `BaseUrl` | `*string` | `nil` | Base url |
+| `ModelHint` | `*string` | `nil` | Model hint |
+| `TimeoutSecs` | `*uint64` | `nil` | Timeout secs |
+| `MaxRetries` | `*uint32` | `nil` | Maximum retries |
+| `ExtraHeaders` | `*map[string]string` | `nil` | Extra headers |
+| `Cache` | `*FileCacheConfig` | `nil` | Cache (file cache config) |
+| `Budget` | `*FileBudgetConfig` | `nil` | Budget (file budget config) |
+| `CooldownSecs` | `*uint64` | `nil` | Cooldown secs |
+| `RateLimit` | `*FileRateLimitConfig` | `nil` | Rate limit (file rate limit config) |
+| `HealthCheckSecs` | `*uint64` | `nil` | Health check secs |
+| `CostTracking` | `*bool` | `nil` | Cost tracking |
+| `Tracing` | `*bool` | `nil` | Tracing |
+| `Providers` | `*[]FileProviderConfig` | `nil` | Providers |
+
+##### Methods
+
+###### FromTomlFile()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```go
+func (o *FileConfig) FromTomlFile(path Path) (FileConfig, error)
+```
+
+###### FromTomlStr()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```go
+func (o *FileConfig) FromTomlStr(s string) (FileConfig, error)
+```
+
+###### Discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```go
+func (o *FileConfig) Discover() (*FileConfig, error)
+```
+
+###### IntoBuilder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```go
+func (o *FileConfig) IntoBuilder() ClientConfigBuilder
+```
+
+###### Providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```go
+func (o *FileConfig) Providers() []FileProviderConfig
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Name` | `string` | — | The name |
+| `BaseUrl` | `string` | — | Base url |
+| `AuthHeader` | `*string` | `nil` | Auth header |
+| `ModelPrefixes` | `[]string` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `Rpm` | `*uint32` | `nil` | Rpm |
+| `Tpm` | `*uint64` | `nil` | Tpm |
+| `WindowSeconds` | `*uint64` | `nil` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### IsTransient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```go
+func (o *LiterLlmError) IsTransient() bool
+```
+
+###### ErrorType()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```go
+func (o *LiterLlmError) ErrorType() string
+```
+
+###### FromStatus()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```go
+func (o *LiterLlmError) FromStatus(status uint16, body string, retryAfter time.Duration) LiterLlmError
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### Chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Chat(req ChatCompletionRequest) (ChatCompletionResponse, error)
+```
+
+###### ChatStream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```go
+func (o *LlmClient) ChatStream(req ChatCompletionRequest) (BoxStream, error)
+```
+
+###### Embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Embed(req EmbeddingRequest) (EmbeddingResponse, error)
+```
+
+###### ListModels()
+
+List available models.
+
+**Signature:**
+
+```go
+func (o *LlmClient) ListModels() (ModelsListResponse, error)
+```
+
+###### ImageGenerate()
+
+Generate an image.
+
+**Signature:**
+
+```go
+func (o *LlmClient) ImageGenerate(req CreateImageRequest) (ImagesResponse, error)
+```
+
+###### Speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Speech(req CreateSpeechRequest) ([]byte, error)
+```
+
+###### Transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Transcribe(req CreateTranscriptionRequest) (TranscriptionResponse, error)
+```
+
+###### Moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Moderate(req ModerationRequest) (ModerationResponse, error)
+```
+
+###### Rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Rerank(req RerankRequest) (RerankResponse, error)
+```
+
+###### Search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Search(req SearchRequest) (SearchResponse, error)
+```
+
+###### Ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```go
+func (o *LlmClient) Ocr(req OcrRequest) (OcrResponse, error)
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### ChatRaw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) ChatRaw(req ChatCompletionRequest) (RawExchange, error)
+```
+
+###### ChatStreamRaw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) ChatStreamRaw(req ChatCompletionRequest) (RawStreamExchange, error)
+```
+
+###### EmbedRaw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) EmbedRaw(req EmbeddingRequest) (RawExchange, error)
+```
+
+###### ImageGenerateRaw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) ImageGenerateRaw(req CreateImageRequest) (RawExchange, error)
+```
+
+###### TranscribeRaw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) TranscribeRaw(req CreateTranscriptionRequest) (RawExchange, error)
+```
+
+###### ModerateRaw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) ModerateRaw(req ModerationRequest) (RawExchange, error)
+```
+
+###### RerankRaw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) RerankRaw(req RerankRequest) (RawExchange, error)
+```
+
+###### SearchRaw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) SearchRaw(req SearchRequest) (RawExchange, error)
+```
+
+###### OcrRaw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```go
+func (o *LlmClientRaw) OcrRaw(req OcrRequest) (RawExchange, error)
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### New()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```go
+func (o *ManagedClient) New(config ClientConfig, modelHint string) (ManagedClient, error)
+```
+
+###### Inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Inner() DefaultClient
+```
+
+###### BudgetState()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```go
+func (o *ManagedClient) BudgetState() *BudgetState
+```
+
+###### HasMiddleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```go
+func (o *ManagedClient) HasMiddleware() bool
+```
+
+###### Chat()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Chat(req ChatCompletionRequest) (ChatCompletionResponse, error)
+```
+
+###### ChatStream()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) ChatStream(req ChatCompletionRequest) (BoxStream, error)
+```
+
+###### Embed()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Embed(req EmbeddingRequest) (EmbeddingResponse, error)
+```
+
+###### ListModels()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) ListModels() (ModelsListResponse, error)
+```
+
+###### ImageGenerate()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) ImageGenerate(req CreateImageRequest) (ImagesResponse, error)
+```
+
+###### Speech()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Speech(req CreateSpeechRequest) ([]byte, error)
+```
+
+###### Transcribe()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Transcribe(req CreateTranscriptionRequest) (TranscriptionResponse, error)
+```
+
+###### Moderate()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Moderate(req ModerationRequest) (ModerationResponse, error)
+```
+
+###### Rerank()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Rerank(req RerankRequest) (RerankResponse, error)
+```
+
+###### Search()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Search(req SearchRequest) (SearchResponse, error)
+```
+
+###### Ocr()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) Ocr(req OcrRequest) (OcrResponse, error)
+```
+
+###### CreateFile()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) CreateFile(req CreateFileRequest) (FileObject, error)
+```
+
+###### RetrieveFile()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) RetrieveFile(fileId string) (FileObject, error)
+```
+
+###### DeleteFile()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) DeleteFile(fileId string) (DeleteResponse, error)
+```
+
+###### ListFiles()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) ListFiles(query FileListQuery) (FileListResponse, error)
+```
+
+###### FileContent()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) FileContent(fileId string) ([]byte, error)
+```
+
+###### CreateBatch()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) CreateBatch(req CreateBatchRequest) (BatchObject, error)
+```
+
+###### RetrieveBatch()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) RetrieveBatch(batchId string) (BatchObject, error)
+```
+
+###### ListBatches()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) ListBatches(query BatchListQuery) (BatchListResponse, error)
+```
+
+###### CancelBatch()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) CancelBatch(batchId string) (BatchObject, error)
+```
+
+###### CreateResponse()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) CreateResponse(req CreateResponseRequest) (ResponseObject, error)
+```
+
+###### RetrieveResponse()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) RetrieveResponse(id string) (ResponseObject, error)
+```
+
+###### CancelResponse()
+
+**Signature:**
+
+```go
+func (o *ManagedClient) CancelResponse(id string) (ResponseObject, error)
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `Model` | `string` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `Document` | `OcrDocument` | — | The document to process. |
-| `Pages` | `*[]uint32` | `nil` | Specific pages to process (1-indexed). `nil` means all pages. |
+| `Pages` | `*[]uint32` | `nil` | Specific pages to process (1-indexed). `None` means all pages. |
 | `IncludeImageBase64` | `*bool` | `nil` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `Text` | `string` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### CreateResponse()
+
+Create a new response.
+
+**Signature:**
+
+```go
+func (o *ResponseClient) CreateResponse(req CreateResponseRequest) (ResponseObject, error)
+```
+
+###### RetrieveResponse()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```go
+func (o *ResponseClient) RetrieveResponse(id string) (ResponseObject, error)
+```
+
+###### CancelResponse()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```go
+func (o *ResponseClient) CancelResponse(id string) (ResponseObject, error)
+```
 
 
 ---
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-java.md
+++ b/docs/reference/api-java.md
@@ -31,8 +31,8 @@ public static DefaultClient createClient(String apiKey, String baseUrl, long tim
 |------|------|----------|-------------|
 | `apiKey` | `String` | Yes | The api key |
 | `baseUrl` | `Optional<String>` | No | The base url |
-| `timeoutSecs` | `Optional<Long>` | No | The timeout secs |
-| `maxRetries` | `Optional<Integer>` | No | The max retries |
+| `timeoutSecs` | `Optional<long>` | No | The timeout secs |
+| `maxRetries` | `Optional<int>` | No | The max retries |
 | `modelHint` | `Optional<String>` | No | The model hint |
 
 **Returns:** `DefaultClient`
@@ -135,6 +135,20 @@ public static boolean unregisterCustomProvider(String name) throws Error
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `String` | — | Message |
+| `errorType` | `String` | — | Error type |
+| `param` | `Optional<String>` | `null` | Param |
+| `code` | `Optional<String>` | `null` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ public static boolean unregisterCustomProvider(String name) throws Error
 |-------|------|---------|-------------|
 | `data` | `String` | — | Base64-encoded audio data. |
 | `format` | `String` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### createBatch()
+
+Create a new batch job.
+
+**Signature:**
+
+```java
+public BatchObject createBatch(CreateBatchRequest req) throws Error
+```
+
+###### retrieveBatch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```java
+public BatchObject retrieveBatch(String batchId) throws Error
+```
+
+###### listBatches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```java
+public BatchListResponse listBatches(BatchListQuery query) throws Error
+```
+
+###### cancelBatch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```java
+public BatchObject cancelBatch(String batchId) throws Error
+```
 
 
 ---
@@ -180,22 +243,22 @@ public static boolean unregisterCustomProvider(String name) throws Error
 |-------|------|---------|-------------|
 | `model` | `String` | — | Model |
 | `messages` | `List<Message>` | `Collections.emptyList()` | Messages |
-| `temperature` | `Optional<Double>` | `null` | Temperature |
-| `topP` | `Optional<Double>` | `null` | Top p |
-| `n` | `Optional<Integer>` | `null` | N |
-| `stream` | `Optional<Boolean>` | `null` | Whether to stream the response. Managed by the client layer — do not set directly. |
+| `temperature` | `Optional<double>` | `null` | Temperature |
+| `topP` | `Optional<double>` | `null` | Top p |
+| `n` | `Optional<int>` | `null` | N |
+| `stream` | `Optional<boolean>` | `null` | Whether to stream the response. Managed by the client layer — do not set directly. |
 | `stop` | `Optional<StopSequence>` | `null` | Stop (stop sequence) |
-| `maxTokens` | `Optional<Long>` | `null` | Maximum tokens |
-| `presencePenalty` | `Optional<Double>` | `null` | Presence penalty |
-| `frequencyPenalty` | `Optional<Double>` | `null` | Frequency penalty |
+| `maxTokens` | `Optional<long>` | `null` | Maximum tokens |
+| `presencePenalty` | `Optional<double>` | `null` | Presence penalty |
+| `frequencyPenalty` | `Optional<double>` | `null` | Frequency penalty |
 | `logitBias` | `Optional<Map<String, Double>>` | `Collections.emptyMap()` | Token bias map.  Uses `BTreeMap` (sorted keys) for deterministic serialization order — important when hashing or signing requests. |
 | `user` | `Optional<String>` | `null` | User |
 | `tools` | `Optional<List<ChatCompletionTool>>` | `Collections.emptyList()` | Tools |
 | `toolChoice` | `Optional<ToolChoice>` | `null` | Tool choice (tool choice) |
-| `parallelToolCalls` | `Optional<Boolean>` | `null` | Parallel tool calls |
+| `parallelToolCalls` | `Optional<boolean>` | `null` | Parallel tool calls |
 | `responseFormat` | `Optional<ResponseFormat>` | `null` | Response format (response format) |
 | `streamOptions` | `Optional<StreamOptions>` | `null` | Stream options (stream options) |
-| `seed` | `Optional<Long>` | `null` | Seed |
+| `seed` | `Optional<long>` | `null` | Seed |
 | `reasoningEffort` | `Optional<ReasoningEffort>` | `null` | Reasoning effort (reasoning effort) |
 | `extraBody` | `Optional<Object>` | `null` | Provider-specific extra parameters merged into the request body. Use for guardrails, safety settings, grounding config, etc. |
 
@@ -214,6 +277,22 @@ public static boolean unregisterCustomProvider(String name) throws Error
 | `usage` | `Optional<Usage>` | `null` | Usage (usage) |
 | `systemFingerprint` | `Optional<String>` | `null` | System fingerprint |
 | `serviceTier` | `Optional<String>` | `null` | Service tier |
+
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```java
+public Optional<Double> estimatedCost()
+```
 
 
 ---
@@ -239,6 +318,290 @@ public static boolean unregisterCustomProvider(String name) throws Error
 
 ---
 
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `String` | — | API key for authentication (stored as a secret). |
+| `baseUrl` | `Optional<String>` | `null` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `Duration` | — | Request timeout. |
+| `maxRetries` | `int` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credentialProvider` | `Optional<CredentialProvider>` | `null` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `loadEnv` | `boolean` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```java
+public List<Tuple<String, String>> headers()
+```
+
+###### fmt()
+
+**Signature:**
+
+```java
+public Unknown fmt(Formatter f)
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### fromEnv()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```java
+public static ClientConfigBuilder fromEnv()
+```
+
+###### loadEnv()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder loadEnv(boolean enabled)
+```
+
+###### baseUrl()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder baseUrl(String url)
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```java
+public ClientConfigBuilder timeout(Duration timeout)
+```
+
+###### maxRetries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```java
+public ClientConfigBuilder maxRetries(int retries)
+```
+
+###### credentialProvider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder credentialProvider(CredentialProvider provider)
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder header(String key, String value) throws Error
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder cache(CacheConfig config)
+```
+
+###### cacheStore()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder cacheStore(CacheStore store)
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder budget(BudgetConfig config)
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```java
+public ClientConfigBuilder hook(LlmHook hook)
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder hooks(List<LlmHook> hooks)
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```java
+public ClientConfigBuilder cooldown(Duration duration)
+```
+
+###### rateLimit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder rateLimit(RateLimitConfig config)
+```
+
+###### healthCheck()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder healthCheck(Duration interval)
+```
+
+###### costTracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder costTracking(boolean enabled)
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder tracing(boolean enabled)
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```java
+public ClientConfig build()
+```
+
+
+---
+
 #### CreateImageRequest
 
 Request to create images from a text prompt.
@@ -247,7 +610,7 @@ Request to create images from a text prompt.
 |-------|------|---------|-------------|
 | `prompt` | `String` | — | Prompt |
 | `model` | `Optional<String>` | `null` | Model |
-| `n` | `Optional<Integer>` | `null` | N |
+| `n` | `Optional<int>` | `null` | N |
 | `size` | `Optional<String>` | `null` | Size in bytes |
 | `quality` | `Optional<String>` | `null` | Quality |
 | `style` | `Optional<String>` | `null` | Style |
@@ -267,7 +630,7 @@ Request to generate speech audio from text.
 | `input` | `String` | — | Input |
 | `voice` | `String` | — | Voice |
 | `responseFormat` | `Optional<String>` | `null` | Response format |
-| `speed` | `Optional<Double>` | `null` | Speed |
+| `speed` | `Optional<double>` | `null` | Speed |
 
 
 ---
@@ -283,7 +646,7 @@ Request to transcribe audio into text.
 | `language` | `Optional<String>` | `null` | Language |
 | `prompt` | `Optional<String>` | `null` | Prompt |
 | `responseFormat` | `Optional<String>` | `null` | Response format |
-| `temperature` | `Optional<Double>` | `null` | Temperature |
+| `temperature` | `Optional<double>` | `null` | Temperature |
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `null` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```java
+public static DefaultClient new(ClientConfig config, String modelHint) throws Error
+```
+
 ###### chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ public ChatCompletionResponse chat(ChatCompletionRequest req) throws Error
 **Signature:**
 
 ```java
-public String chatStream(ChatCompletionRequest req) throws Error
+public BoxStream chatStream(ChatCompletionRequest req) throws Error
 ```
 
 ###### embed()
@@ -358,6 +742,14 @@ public ModelsListResponse listModels() throws Error
 
 ```java
 public ImagesResponse imageGenerate(CreateImageRequest req) throws Error
+```
+
+###### speech()
+
+**Signature:**
+
+```java
+public byte[] speech(CreateSpeechRequest req) throws Error
 ```
 
 ###### transcribe()
@@ -390,6 +782,182 @@ public RerankResponse rerank(RerankRequest req) throws Error
 
 ```java
 public SearchResponse search(SearchRequest req) throws Error
+```
+
+###### ocr()
+
+**Signature:**
+
+```java
+public OcrResponse ocr(OcrRequest req) throws Error
+```
+
+###### chatRaw()
+
+**Signature:**
+
+```java
+public RawExchange chatRaw(ChatCompletionRequest req) throws Error
+```
+
+###### chatStreamRaw()
+
+**Signature:**
+
+```java
+public RawStreamExchange chatStreamRaw(ChatCompletionRequest req) throws Error
+```
+
+###### embedRaw()
+
+**Signature:**
+
+```java
+public RawExchange embedRaw(EmbeddingRequest req) throws Error
+```
+
+###### imageGenerateRaw()
+
+**Signature:**
+
+```java
+public RawExchange imageGenerateRaw(CreateImageRequest req) throws Error
+```
+
+###### transcribeRaw()
+
+**Signature:**
+
+```java
+public RawExchange transcribeRaw(CreateTranscriptionRequest req) throws Error
+```
+
+###### moderateRaw()
+
+**Signature:**
+
+```java
+public RawExchange moderateRaw(ModerationRequest req) throws Error
+```
+
+###### rerankRaw()
+
+**Signature:**
+
+```java
+public RawExchange rerankRaw(RerankRequest req) throws Error
+```
+
+###### searchRaw()
+
+**Signature:**
+
+```java
+public RawExchange searchRaw(SearchRequest req) throws Error
+```
+
+###### ocrRaw()
+
+**Signature:**
+
+```java
+public RawExchange ocrRaw(OcrRequest req) throws Error
+```
+
+###### createFile()
+
+**Signature:**
+
+```java
+public FileObject createFile(CreateFileRequest req) throws Error
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```java
+public FileObject retrieveFile(String fileId) throws Error
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```java
+public DeleteResponse deleteFile(String fileId) throws Error
+```
+
+###### listFiles()
+
+**Signature:**
+
+```java
+public FileListResponse listFiles(FileListQuery query) throws Error
+```
+
+###### fileContent()
+
+**Signature:**
+
+```java
+public byte[] fileContent(String fileId) throws Error
+```
+
+###### createBatch()
+
+**Signature:**
+
+```java
+public BatchObject createBatch(CreateBatchRequest req) throws Error
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```java
+public BatchObject retrieveBatch(String batchId) throws Error
+```
+
+###### listBatches()
+
+**Signature:**
+
+```java
+public BatchListResponse listBatches(BatchListQuery query) throws Error
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```java
+public BatchObject cancelBatch(String batchId) throws Error
+```
+
+###### createResponse()
+
+**Signature:**
+
+```java
+public ResponseObject createResponse(CreateResponseRequest req) throws Error
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```java
+public ResponseObject retrieveResponse(String id) throws Error
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```java
+public ResponseObject cancelResponse(String id) throws Error
 ```
 
 
@@ -433,7 +1001,7 @@ public SearchResponse search(SearchRequest req) throws Error
 | `model` | `String` | — | Model |
 | `input` | `EmbeddingInput` | — | Input (embedding input) |
 | `encodingFormat` | `Optional<EmbeddingFormat>` | `null` | Encoding format (embedding format) |
-| `dimensions` | `Optional<Integer>` | `null` | Dimensions |
+| `dimensions` | `Optional<int>` | `null` | Dimensions |
 | `user` | `Optional<String>` | `null` | User |
 
 
@@ -447,6 +1015,247 @@ public SearchResponse search(SearchRequest req) throws Error
 | `data` | `List<EmbeddingObject>` | — | Data |
 | `model` | `String` | — | Model |
 | `usage` | `Optional<Usage>` | `null` | Usage (usage) |
+
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```java
+public Optional<Double> estimatedCost()
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `globalLimit` | `Optional<double>` | `null` | Global limit |
+| `modelLimits` | `Optional<Map<String, Double>>` | `null` | Model limits |
+| `enforcement` | `Optional<String>` | `null` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `maxEntries` | `Optional<long>` | `null` | Maximum entries |
+| `ttlSeconds` | `Optional<long>` | `null` | Ttl seconds |
+| `backend` | `Optional<String>` | `null` | Backend |
+| `backendConfig` | `Optional<Map<String, String>>` | `null` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### createFile()
+
+Upload a file.
+
+**Signature:**
+
+```java
+public FileObject createFile(CreateFileRequest req) throws Error
+```
+
+###### retrieveFile()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```java
+public FileObject retrieveFile(String fileId) throws Error
+```
+
+###### deleteFile()
+
+Delete a file.
+
+**Signature:**
+
+```java
+public DeleteResponse deleteFile(String fileId) throws Error
+```
+
+###### listFiles()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```java
+public FileListResponse listFiles(FileListQuery query) throws Error
+```
+
+###### fileContent()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```java
+public byte[] fileContent(String fileId) throws Error
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `Optional<String>` | `null` | Api key |
+| `baseUrl` | `Optional<String>` | `null` | Base url |
+| `modelHint` | `Optional<String>` | `null` | Model hint |
+| `timeoutSecs` | `Optional<long>` | `null` | Timeout secs |
+| `maxRetries` | `Optional<int>` | `null` | Maximum retries |
+| `extraHeaders` | `Optional<Map<String, String>>` | `null` | Extra headers |
+| `cache` | `Optional<FileCacheConfig>` | `null` | Cache (file cache config) |
+| `budget` | `Optional<FileBudgetConfig>` | `null` | Budget (file budget config) |
+| `cooldownSecs` | `Optional<long>` | `null` | Cooldown secs |
+| `rateLimit` | `Optional<FileRateLimitConfig>` | `null` | Rate limit (file rate limit config) |
+| `healthCheckSecs` | `Optional<long>` | `null` | Health check secs |
+| `costTracking` | `Optional<boolean>` | `null` | Cost tracking |
+| `tracing` | `Optional<boolean>` | `null` | Tracing |
+| `providers` | `Optional<List<FileProviderConfig>>` | `null` | Providers |
+
+##### Methods
+
+###### fromTomlFile()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```java
+public static FileConfig fromTomlFile(Path path) throws Error
+```
+
+###### fromTomlStr()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```java
+public static FileConfig fromTomlStr(String s) throws Error
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```java
+public static Optional<FileConfig> discover() throws Error
+```
+
+###### intoBuilder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```java
+public ClientConfigBuilder intoBuilder()
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```java
+public List<FileProviderConfig> providers()
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `String` | — | The name |
+| `baseUrl` | `String` | — | Base url |
+| `authHeader` | `Optional<String>` | `null` | Auth header |
+| `modelPrefixes` | `List<String>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `Optional<int>` | `null` | Rpm |
+| `tpm` | `Optional<long>` | `null` | Tpm |
+| `windowSeconds` | `Optional<long>` | `null` | Window seconds |
 
 
 ---
@@ -468,7 +1277,7 @@ public SearchResponse search(SearchRequest req) throws Error
 | `name` | `String` | — | The name |
 | `description` | `Optional<String>` | `null` | Human-readable description |
 | `parameters` | `Optional<Object>` | `null` | Parameters |
-| `strict` | `Optional<Boolean>` | `null` | Strict |
+| `strict` | `Optional<boolean>` | `null` | Strict |
 
 
 ---
@@ -527,12 +1336,548 @@ Response containing generated images.
 | `name` | `String` | — | The name |
 | `description` | `Optional<String>` | `null` | Human-readable description |
 | `schema` | `Object` | — | Schema |
-| `strict` | `Optional<Boolean>` | `null` | Strict |
+| `strict` | `Optional<boolean>` | `null` | Strict |
 
 
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### isTransient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```java
+public boolean isTransient()
+```
+
+###### errorType()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```java
+public String errorType()
+```
+
+###### fromStatus()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```java
+public static LiterLlmError fromStatus(short status, String body, Duration retryAfter)
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```java
+public ChatCompletionResponse chat(ChatCompletionRequest req) throws Error
+```
+
+###### chatStream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```java
+public BoxStream chatStream(ChatCompletionRequest req) throws Error
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```java
+public EmbeddingResponse embed(EmbeddingRequest req) throws Error
+```
+
+###### listModels()
+
+List available models.
+
+**Signature:**
+
+```java
+public ModelsListResponse listModels() throws Error
+```
+
+###### imageGenerate()
+
+Generate an image.
+
+**Signature:**
+
+```java
+public ImagesResponse imageGenerate(CreateImageRequest req) throws Error
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```java
+public byte[] speech(CreateSpeechRequest req) throws Error
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```java
+public TranscriptionResponse transcribe(CreateTranscriptionRequest req) throws Error
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```java
+public ModerationResponse moderate(ModerationRequest req) throws Error
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```java
+public RerankResponse rerank(RerankRequest req) throws Error
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```java
+public SearchResponse search(SearchRequest req) throws Error
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```java
+public OcrResponse ocr(OcrRequest req) throws Error
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chatRaw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```java
+public RawExchange chatRaw(ChatCompletionRequest req) throws Error
+```
+
+###### chatStreamRaw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```java
+public RawStreamExchange chatStreamRaw(ChatCompletionRequest req) throws Error
+```
+
+###### embedRaw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange embedRaw(EmbeddingRequest req) throws Error
+```
+
+###### imageGenerateRaw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange imageGenerateRaw(CreateImageRequest req) throws Error
+```
+
+###### transcribeRaw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange transcribeRaw(CreateTranscriptionRequest req) throws Error
+```
+
+###### moderateRaw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange moderateRaw(ModerationRequest req) throws Error
+```
+
+###### rerankRaw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange rerankRaw(RerankRequest req) throws Error
+```
+
+###### searchRaw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange searchRaw(SearchRequest req) throws Error
+```
+
+###### ocrRaw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```java
+public RawExchange ocrRaw(OcrRequest req) throws Error
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```java
+public static ManagedClient new(ClientConfig config, String modelHint) throws Error
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```java
+public DefaultClient inner()
+```
+
+###### budgetState()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```java
+public Optional<BudgetState> budgetState()
+```
+
+###### hasMiddleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```java
+public boolean hasMiddleware()
+```
+
+###### chat()
+
+**Signature:**
+
+```java
+public ChatCompletionResponse chat(ChatCompletionRequest req) throws Error
+```
+
+###### chatStream()
+
+**Signature:**
+
+```java
+public BoxStream chatStream(ChatCompletionRequest req) throws Error
+```
+
+###### embed()
+
+**Signature:**
+
+```java
+public EmbeddingResponse embed(EmbeddingRequest req) throws Error
+```
+
+###### listModels()
+
+**Signature:**
+
+```java
+public ModelsListResponse listModels() throws Error
+```
+
+###### imageGenerate()
+
+**Signature:**
+
+```java
+public ImagesResponse imageGenerate(CreateImageRequest req) throws Error
+```
+
+###### speech()
+
+**Signature:**
+
+```java
+public byte[] speech(CreateSpeechRequest req) throws Error
+```
+
+###### transcribe()
+
+**Signature:**
+
+```java
+public TranscriptionResponse transcribe(CreateTranscriptionRequest req) throws Error
+```
+
+###### moderate()
+
+**Signature:**
+
+```java
+public ModerationResponse moderate(ModerationRequest req) throws Error
+```
+
+###### rerank()
+
+**Signature:**
+
+```java
+public RerankResponse rerank(RerankRequest req) throws Error
+```
+
+###### search()
+
+**Signature:**
+
+```java
+public SearchResponse search(SearchRequest req) throws Error
+```
+
+###### ocr()
+
+**Signature:**
+
+```java
+public OcrResponse ocr(OcrRequest req) throws Error
+```
+
+###### createFile()
+
+**Signature:**
+
+```java
+public FileObject createFile(CreateFileRequest req) throws Error
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```java
+public FileObject retrieveFile(String fileId) throws Error
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```java
+public DeleteResponse deleteFile(String fileId) throws Error
+```
+
+###### listFiles()
+
+**Signature:**
+
+```java
+public FileListResponse listFiles(FileListQuery query) throws Error
+```
+
+###### fileContent()
+
+**Signature:**
+
+```java
+public byte[] fileContent(String fileId) throws Error
+```
+
+###### createBatch()
+
+**Signature:**
+
+```java
+public BatchObject createBatch(CreateBatchRequest req) throws Error
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```java
+public BatchObject retrieveBatch(String batchId) throws Error
+```
+
+###### listBatches()
+
+**Signature:**
+
+```java
+public BatchListResponse listBatches(BatchListQuery query) throws Error
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```java
+public BatchObject cancelBatch(String batchId) throws Error
+```
+
+###### createResponse()
+
+**Signature:**
+
+```java
+public ResponseObject createResponse(CreateResponseRequest req) throws Error
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```java
+public ResponseObject retrieveResponse(String id) throws Error
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```java
+public ResponseObject cancelResponse(String id) throws Error
+```
 
 
 ---
@@ -673,8 +2018,8 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `String` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `OcrDocument` | — | The document to process. |
-| `pages` | `Optional<List<Integer>>` | `null` | Specific pages to process (1-indexed). `null` means all pages. |
-| `includeImageBase64` | `Optional<Boolean>` | `null` | Whether to include base64-encoded images of each page. |
+| `pages` | `Optional<List<Integer>>` | `null` | Specific pages to process (1-indexed). `None` means all pages. |
+| `includeImageBase64` | `Optional<boolean>` | `null` | Whether to include base64-encoded images of each page. |
 
 
 ---
@@ -713,8 +2058,8 @@ Request to rerank documents by relevance to a query.
 | `model` | `String` | — | Model |
 | `query` | `String` | — | Query |
 | `documents` | `List<RerankDocument>` | — | Documents |
-| `topN` | `Optional<Integer>` | `null` | Top n |
-| `returnDocuments` | `Optional<Boolean>` | `null` | Return documents |
+| `topN` | `Optional<int>` | `null` | Top n |
+| `returnDocuments` | `Optional<boolean>` | `null` | Return documents |
 
 
 ---
@@ -756,6 +2101,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 
 ---
 
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### createResponse()
+
+Create a new response.
+
+**Signature:**
+
+```java
+public ResponseObject createResponse(CreateResponseRequest req) throws Error
+```
+
+###### retrieveResponse()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```java
+public ResponseObject retrieveResponse(String id) throws Error
+```
+
+###### cancelResponse()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```java
+public ResponseObject cancelResponse(String id) throws Error
+```
+
+
+---
+
 #### SearchRequest
 
 A search request.
@@ -764,7 +2148,7 @@ A search request.
 |-------|------|---------|-------------|
 | `model` | `String` | — | The model/provider to use (e.g. `"brave/web-search"`, `"tavily/search"`). |
 | `query` | `String` | — | The search query. |
-| `maxResults` | `Optional<Integer>` | `null` | Maximum number of results to return. |
+| `maxResults` | `Optional<int>` | `null` | Maximum number of results to return. |
 | `searchDomainFilter` | `Optional<List<String>>` | `Collections.emptyList()` | Domain filter — restrict results to specific domains. |
 | `country` | `Optional<String>` | `null` | Country code for localized results (ISO 3166-1 alpha-2). |
 
@@ -854,7 +2238,7 @@ An individual search result.
 
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
-| `includeUsage` | `Optional<Boolean>` | `null` | Include usage |
+| `includeUsage` | `Optional<boolean>` | `null` | Include usage |
 
 
 ---
@@ -911,7 +2295,7 @@ Response from a transcription request.
 |-------|------|---------|-------------|
 | `text` | `String` | — | Text |
 | `language` | `Optional<String>` | `null` | Language |
-| `duration` | `Optional<Double>` | `null` | Duration |
+| `duration` | `Optional<double>` | `null` | Duration |
 | `segments` | `Optional<List<TranscriptionSegment>>` | `Collections.emptyList()` | Segments |
 
 
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-php.md
+++ b/docs/reference/api-php.md
@@ -135,6 +135,20 @@ public static function unregisterCustomProvider(string $name): bool
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `string` | — | Message |
+| `errorType` | `string` | — | Error type |
+| `param` | `?string` | `null` | Param |
+| `code` | `?string` | `null` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ public static function unregisterCustomProvider(string $name): bool
 |-------|------|---------|-------------|
 | `data` | `string` | — | Base64-encoded audio data. |
 | `format` | `string` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### createBatch()
+
+Create a new batch job.
+
+**Signature:**
+
+```php
+public function createBatch(CreateBatchRequest $req): BatchObject
+```
+
+###### retrieveBatch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```php
+public function retrieveBatch(string $batchId): BatchObject
+```
+
+###### listBatches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```php
+public function listBatches(BatchListQuery $query): BatchListResponse
+```
+
+###### cancelBatch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```php
+public function cancelBatch(string $batchId): BatchObject
+```
 
 
 ---
@@ -215,6 +278,22 @@ public static function unregisterCustomProvider(string $name): bool
 | `systemFingerprint` | `?string` | `null` | System fingerprint |
 | `serviceTier` | `?string` | `null` | Service tier |
 
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```php
+public function estimatedCost(): ?float
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ public static function unregisterCustomProvider(string $name): bool
 | `index` | `int` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finishReason` | `?FinishReason` | `null` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy::ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `string` | — | API key for authentication (stored as a secret). |
+| `baseUrl` | `?string` | `null` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `float` | — | Request timeout. |
+| `maxRetries` | `int` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credentialProvider` | `?CredentialProvider` | `null` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `loadEnv` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```php
+public function headers(): array<array{string, string}>
+```
+
+###### fmt()
+
+**Signature:**
+
+```php
+public function fmt(Formatter $f): Unknown
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder::new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder::build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### fromEnv()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```php
+public static function fromEnv(): ClientConfigBuilder
+```
+
+###### loadEnv()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient::new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```php
+public function loadEnv(bool $enabled): ClientConfigBuilder
+```
+
+###### baseUrl()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```php
+public function baseUrl(string $url): ClientConfigBuilder
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```php
+public function timeout(float $timeout): ClientConfigBuilder
+```
+
+###### maxRetries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```php
+public function maxRetries(int $retries): ClientConfigBuilder
+```
+
+###### credentialProvider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```php
+public function credentialProvider(CredentialProvider $provider): ClientConfigBuilder
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```php
+public function header(string $key, string $value): ClientConfigBuilder
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```php
+public function cache(CacheConfig $config): ClientConfigBuilder
+```
+
+###### cacheStore()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```php
+public function cacheStore(CacheStore $store): ClientConfigBuilder
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```php
+public function budget(BudgetConfig $config): ClientConfigBuilder
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```php
+public function hook(LlmHook $hook): ClientConfigBuilder
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```php
+public function hooks(array<LlmHook> $hooks): ClientConfigBuilder
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```php
+public function cooldown(float $duration): ClientConfigBuilder
+```
+
+###### rateLimit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError::RateLimited`.
+
+**Signature:**
+
+```php
+public function rateLimit(RateLimitConfig $config): ClientConfigBuilder
+```
+
+###### healthCheck()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```php
+public function healthCheck(float $interval): ClientConfigBuilder
+```
+
+###### costTracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```php
+public function costTracking(bool $enabled): ClientConfigBuilder
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```php
+public function tracing(bool $enabled): ClientConfigBuilder
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```php
+public function build(): ClientConfig
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `null` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest::Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder::header`, so they are inserted directly here.
+
+**Signature:**
+
+```php
+public static function new(ClientConfig $config, string $modelHint): DefaultClient
+```
+
 ###### chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ public function chat(ChatCompletionRequest $req): ChatCompletionResponse
 **Signature:**
 
 ```php
-public function chatStream(ChatCompletionRequest $req): string
+public function chatStream(ChatCompletionRequest $req): BoxStream
 ```
 
 ###### embed()
@@ -358,6 +742,14 @@ public function listModels(): ModelsListResponse
 
 ```php
 public function imageGenerate(CreateImageRequest $req): ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```php
+public function speech(CreateSpeechRequest $req): string
 ```
 
 ###### transcribe()
@@ -390,6 +782,182 @@ public function rerank(RerankRequest $req): RerankResponse
 
 ```php
 public function search(SearchRequest $req): SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```php
+public function ocr(OcrRequest $req): OcrResponse
+```
+
+###### chatRaw()
+
+**Signature:**
+
+```php
+public function chatRaw(ChatCompletionRequest $req): RawExchange
+```
+
+###### chatStreamRaw()
+
+**Signature:**
+
+```php
+public function chatStreamRaw(ChatCompletionRequest $req): RawStreamExchange
+```
+
+###### embedRaw()
+
+**Signature:**
+
+```php
+public function embedRaw(EmbeddingRequest $req): RawExchange
+```
+
+###### imageGenerateRaw()
+
+**Signature:**
+
+```php
+public function imageGenerateRaw(CreateImageRequest $req): RawExchange
+```
+
+###### transcribeRaw()
+
+**Signature:**
+
+```php
+public function transcribeRaw(CreateTranscriptionRequest $req): RawExchange
+```
+
+###### moderateRaw()
+
+**Signature:**
+
+```php
+public function moderateRaw(ModerationRequest $req): RawExchange
+```
+
+###### rerankRaw()
+
+**Signature:**
+
+```php
+public function rerankRaw(RerankRequest $req): RawExchange
+```
+
+###### searchRaw()
+
+**Signature:**
+
+```php
+public function searchRaw(SearchRequest $req): RawExchange
+```
+
+###### ocrRaw()
+
+**Signature:**
+
+```php
+public function ocrRaw(OcrRequest $req): RawExchange
+```
+
+###### createFile()
+
+**Signature:**
+
+```php
+public function createFile(CreateFileRequest $req): FileObject
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```php
+public function retrieveFile(string $fileId): FileObject
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```php
+public function deleteFile(string $fileId): DeleteResponse
+```
+
+###### listFiles()
+
+**Signature:**
+
+```php
+public function listFiles(FileListQuery $query): FileListResponse
+```
+
+###### fileContent()
+
+**Signature:**
+
+```php
+public function fileContent(string $fileId): string
+```
+
+###### createBatch()
+
+**Signature:**
+
+```php
+public function createBatch(CreateBatchRequest $req): BatchObject
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```php
+public function retrieveBatch(string $batchId): BatchObject
+```
+
+###### listBatches()
+
+**Signature:**
+
+```php
+public function listBatches(BatchListQuery $query): BatchListResponse
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```php
+public function cancelBatch(string $batchId): BatchObject
+```
+
+###### createResponse()
+
+**Signature:**
+
+```php
+public function createResponse(CreateResponseRequest $req): ResponseObject
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```php
+public function retrieveResponse(string $id): ResponseObject
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```php
+public function cancelResponse(string $id): ResponseObject
 ```
 
 
@@ -447,6 +1015,247 @@ public function search(SearchRequest $req): SearchResponse
 | `data` | `array<EmbeddingObject>` | — | Data |
 | `model` | `string` | — | Model |
 | `usage` | `?Usage` | `null` | Usage (usage) |
+
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```php
+public function estimatedCost(): ?float
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `globalLimit` | `?float` | `null` | Global limit |
+| `modelLimits` | `?array<string, float>` | `null` | Model limits |
+| `enforcement` | `?string` | `null` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `maxEntries` | `?int` | `null` | Maximum entries |
+| `ttlSeconds` | `?int` | `null` | Ttl seconds |
+| `backend` | `?string` | `null` | Backend |
+| `backendConfig` | `?array<string, string>` | `null` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### createFile()
+
+Upload a file.
+
+**Signature:**
+
+```php
+public function createFile(CreateFileRequest $req): FileObject
+```
+
+###### retrieveFile()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```php
+public function retrieveFile(string $fileId): FileObject
+```
+
+###### deleteFile()
+
+Delete a file.
+
+**Signature:**
+
+```php
+public function deleteFile(string $fileId): DeleteResponse
+```
+
+###### listFiles()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```php
+public function listFiles(FileListQuery $query): FileListResponse
+```
+
+###### fileContent()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```php
+public function fileContent(string $fileId): string
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig::into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `?string` | `null` | Api key |
+| `baseUrl` | `?string` | `null` | Base url |
+| `modelHint` | `?string` | `null` | Model hint |
+| `timeoutSecs` | `?int` | `null` | Timeout secs |
+| `maxRetries` | `?int` | `null` | Maximum retries |
+| `extraHeaders` | `?array<string, string>` | `null` | Extra headers |
+| `cache` | `?FileCacheConfig` | `null` | Cache (file cache config) |
+| `budget` | `?FileBudgetConfig` | `null` | Budget (file budget config) |
+| `cooldownSecs` | `?int` | `null` | Cooldown secs |
+| `rateLimit` | `?FileRateLimitConfig` | `null` | Rate limit (file rate limit config) |
+| `healthCheckSecs` | `?int` | `null` | Health check secs |
+| `costTracking` | `?bool` | `null` | Cost tracking |
+| `tracing` | `?bool` | `null` | Tracing |
+| `providers` | `?array<FileProviderConfig>` | `null` | Providers |
+
+##### Methods
+
+###### fromTomlFile()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```php
+public static function fromTomlFile(Path $path): FileConfig
+```
+
+###### fromTomlStr()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```php
+public static function fromTomlStr(string $s): FileConfig
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```php
+public static function discover(): ?FileConfig
+```
+
+###### intoBuilder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```php
+public function intoBuilder(): ClientConfigBuilder
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```php
+public function providers(): array<FileProviderConfig>
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | — | The name |
+| `baseUrl` | `string` | — | Base url |
+| `authHeader` | `?string` | `null` | Auth header |
+| `modelPrefixes` | `array<string>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `?int` | `null` | Rpm |
+| `tpm` | `?int` | `null` | Tpm |
+| `windowSeconds` | `?int` | `null` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### isTransient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate::tower::fallback::FallbackService` and
+`crate::tower::router::Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```php
+public function isTransient(): bool
+```
+
+###### errorType()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```php
+public function errorType(): string
+```
+
+###### fromStatus()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError::RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```php
+public static function fromStatus(int $status, string $body, float $retryAfter): LiterLlmError
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```php
+public function chat(ChatCompletionRequest $req): ChatCompletionResponse
+```
+
+###### chatStream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```php
+public function chatStream(ChatCompletionRequest $req): BoxStream
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```php
+public function embed(EmbeddingRequest $req): EmbeddingResponse
+```
+
+###### listModels()
+
+List available models.
+
+**Signature:**
+
+```php
+public function listModels(): ModelsListResponse
+```
+
+###### imageGenerate()
+
+Generate an image.
+
+**Signature:**
+
+```php
+public function imageGenerate(CreateImageRequest $req): ImagesResponse
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```php
+public function speech(CreateSpeechRequest $req): string
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```php
+public function transcribe(CreateTranscriptionRequest $req): TranscriptionResponse
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```php
+public function moderate(ModerationRequest $req): ModerationResponse
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```php
+public function rerank(RerankRequest $req): RerankResponse
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```php
+public function search(SearchRequest $req): SearchResponse
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```php
+public function ocr(OcrRequest $req): OcrResponse
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chatRaw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```php
+public function chatRaw(ChatCompletionRequest $req): RawExchange
+```
+
+###### chatStreamRaw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```php
+public function chatStreamRaw(ChatCompletionRequest $req): RawStreamExchange
+```
+
+###### embedRaw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```php
+public function embedRaw(EmbeddingRequest $req): RawExchange
+```
+
+###### imageGenerateRaw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```php
+public function imageGenerateRaw(CreateImageRequest $req): RawExchange
+```
+
+###### transcribeRaw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```php
+public function transcribeRaw(CreateTranscriptionRequest $req): RawExchange
+```
+
+###### moderateRaw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```php
+public function moderateRaw(ModerationRequest $req): RawExchange
+```
+
+###### rerankRaw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```php
+public function rerankRaw(RerankRequest $req): RawExchange
+```
+
+###### searchRaw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```php
+public function searchRaw(SearchRequest $req): RawExchange
+```
+
+###### ocrRaw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```php
+public function ocrRaw(OcrRequest $req): RawExchange
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient::new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient::new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```php
+public static function new(ClientConfig $config, string $modelHint): ManagedClient
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```php
+public function inner(): DefaultClient
+```
+
+###### budgetState()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```php
+public function budgetState(): ?BudgetState
+```
+
+###### hasMiddleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```php
+public function hasMiddleware(): bool
+```
+
+###### chat()
+
+**Signature:**
+
+```php
+public function chat(ChatCompletionRequest $req): ChatCompletionResponse
+```
+
+###### chatStream()
+
+**Signature:**
+
+```php
+public function chatStream(ChatCompletionRequest $req): BoxStream
+```
+
+###### embed()
+
+**Signature:**
+
+```php
+public function embed(EmbeddingRequest $req): EmbeddingResponse
+```
+
+###### listModels()
+
+**Signature:**
+
+```php
+public function listModels(): ModelsListResponse
+```
+
+###### imageGenerate()
+
+**Signature:**
+
+```php
+public function imageGenerate(CreateImageRequest $req): ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```php
+public function speech(CreateSpeechRequest $req): string
+```
+
+###### transcribe()
+
+**Signature:**
+
+```php
+public function transcribe(CreateTranscriptionRequest $req): TranscriptionResponse
+```
+
+###### moderate()
+
+**Signature:**
+
+```php
+public function moderate(ModerationRequest $req): ModerationResponse
+```
+
+###### rerank()
+
+**Signature:**
+
+```php
+public function rerank(RerankRequest $req): RerankResponse
+```
+
+###### search()
+
+**Signature:**
+
+```php
+public function search(SearchRequest $req): SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```php
+public function ocr(OcrRequest $req): OcrResponse
+```
+
+###### createFile()
+
+**Signature:**
+
+```php
+public function createFile(CreateFileRequest $req): FileObject
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```php
+public function retrieveFile(string $fileId): FileObject
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```php
+public function deleteFile(string $fileId): DeleteResponse
+```
+
+###### listFiles()
+
+**Signature:**
+
+```php
+public function listFiles(FileListQuery $query): FileListResponse
+```
+
+###### fileContent()
+
+**Signature:**
+
+```php
+public function fileContent(string $fileId): string
+```
+
+###### createBatch()
+
+**Signature:**
+
+```php
+public function createBatch(CreateBatchRequest $req): BatchObject
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```php
+public function retrieveBatch(string $batchId): BatchObject
+```
+
+###### listBatches()
+
+**Signature:**
+
+```php
+public function listBatches(BatchListQuery $query): BatchListResponse
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```php
+public function cancelBatch(string $batchId): BatchObject
+```
+
+###### createResponse()
+
+**Signature:**
+
+```php
+public function createResponse(CreateResponseRequest $req): ResponseObject
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```php
+public function retrieveResponse(string $id): ResponseObject
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```php
+public function cancelResponse(string $id): ResponseObject
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `string` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `OcrDocument` | — | The document to process. |
-| `pages` | `?array<int>` | `null` | Specific pages to process (1-indexed). `null` means all pages. |
+| `pages` | `?array<int>` | `null` | Specific pages to process (1-indexed). `None` means all pages. |
 | `includeImageBase64` | `?bool` | `null` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `string` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### createResponse()
+
+Create a new response.
+
+**Signature:**
+
+```php
+public function createResponse(CreateResponseRequest $req): ResponseObject
+```
+
+###### retrieveResponse()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```php
+public function retrieveResponse(string $id): ResponseObject
+```
+
+###### cancelResponse()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```php
+public function cancelResponse(string $id): ResponseObject
+```
 
 
 ---
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-python.md
+++ b/docs/reference/api-python.md
@@ -135,6 +135,20 @@ def unregister_custom_provider(name: str) -> bool
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `str` | — | Message |
+| `error_type` | `str` | — | Error type |
+| `param` | `str | None` | `None` | Param |
+| `code` | `str | None` | `None` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ def unregister_custom_provider(name: str) -> bool
 |-------|------|---------|-------------|
 | `data` | `str` | — | Base64-encoded audio data. |
 | `format` | `str` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### create_batch()
+
+Create a new batch job.
+
+**Signature:**
+
+```python
+def create_batch(self, req: CreateBatchRequest) -> BatchObject
+```
+
+###### retrieve_batch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```python
+def retrieve_batch(self, batch_id: str) -> BatchObject
+```
+
+###### list_batches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```python
+def list_batches(self, query: BatchListQuery) -> BatchListResponse
+```
+
+###### cancel_batch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```python
+def cancel_batch(self, batch_id: str) -> BatchObject
+```
 
 
 ---
@@ -197,7 +260,7 @@ def unregister_custom_provider(name: str) -> bool
 | `stream_options` | `StreamOptions | None` | `None` | Stream options (stream options) |
 | `seed` | `int | None` | `None` | Seed |
 | `reasoning_effort` | `ReasoningEffort | None` | `None` | Reasoning effort (reasoning effort) |
-| `extra_body` | `dict[str, Any] | None` | `None` | Provider-specific extra parameters merged into the request body. Use for guardrails, safety settings, grounding config, etc. |
+| `extra_body` | `Any | None` | `None` | Provider-specific extra parameters merged into the request body. Use for guardrails, safety settings, grounding config, etc. |
 
 
 ---
@@ -214,6 +277,22 @@ def unregister_custom_provider(name: str) -> bool
 | `usage` | `Usage | None` | `None` | Usage (usage) |
 | `system_fingerprint` | `str | None` | `None` | System fingerprint |
 | `service_tier` | `str | None` | `None` | Service tier |
+
+##### Methods
+
+###### estimated_cost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `None` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```python
+def estimated_cost(self) -> float | None
+```
 
 
 ---
@@ -235,6 +314,291 @@ def unregister_custom_provider(name: str) -> bool
 | `index` | `int` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finish_reason` | `FinishReason | None` | `None` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `str` | — | API key for authentication (stored as a secret). |
+| `base_url` | `str | None` | `None` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `float` | — | Request timeout. |
+| `max_retries` | `int` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `CredentialProvider | None` | `None` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```python
+def headers(self) -> list[tuple[str, str]]
+```
+
+###### fmt()
+
+**Signature:**
+
+```python
+def fmt(self, f: Formatter) -> Unknown
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### from_env()
+
+Create a builder with no explicit API key.
+
+`load_env` is `True` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```python
+@staticmethod
+def from_env() -> ClientConfigBuilder
+```
+
+###### load_env()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `True` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `False` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```python
+def load_env(self, enabled: bool) -> ClientConfigBuilder
+```
+
+###### base_url()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```python
+def base_url(self, url: str) -> ClientConfigBuilder
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```python
+def timeout(self, timeout: float) -> ClientConfigBuilder
+```
+
+###### max_retries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```python
+def max_retries(self, retries: int) -> ClientConfigBuilder
+```
+
+###### credential_provider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```python
+def credential_provider(self, provider: CredentialProvider) -> ClientConfigBuilder
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```python
+def header(self, key: str, value: str) -> ClientConfigBuilder
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```python
+def cache(self, config: CacheConfig) -> ClientConfigBuilder
+```
+
+###### cache_store()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```python
+def cache_store(self, store: CacheStore) -> ClientConfigBuilder
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```python
+def budget(self, config: BudgetConfig) -> ClientConfigBuilder
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```python
+def hook(self, hook: LlmHook) -> ClientConfigBuilder
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```python
+def hooks(self, hooks: list[LlmHook]) -> ClientConfigBuilder
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```python
+def cooldown(self, duration: float) -> ClientConfigBuilder
+```
+
+###### rate_limit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```python
+def rate_limit(self, config: RateLimitConfig) -> ClientConfigBuilder
+```
+
+###### health_check()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```python
+def health_check(self, interval: float) -> ClientConfigBuilder
+```
+
+###### cost_tracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```python
+def cost_tracking(self, enabled: bool) -> ClientConfigBuilder
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```python
+def tracing(self, enabled: bool) -> ClientConfigBuilder
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```python
+def build(self) -> ClientConfig
+```
 
 
 ---
@@ -320,6 +684,28 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `None` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```python
+@staticmethod
+def new(config: ClientConfig, model_hint: str) -> DefaultClient
+```
+
 ###### chat()
 
 **Signature:**
@@ -333,7 +719,7 @@ def chat(self, req: ChatCompletionRequest) -> ChatCompletionResponse
 **Signature:**
 
 ```python
-def chat_stream(self, req: ChatCompletionRequest) -> str
+def chat_stream(self, req: ChatCompletionRequest) -> BoxStream
 ```
 
 ###### embed()
@@ -358,6 +744,14 @@ def list_models(self) -> ModelsListResponse
 
 ```python
 def image_generate(self, req: CreateImageRequest) -> ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```python
+def speech(self, req: CreateSpeechRequest) -> bytes
 ```
 
 ###### transcribe()
@@ -390,6 +784,182 @@ def rerank(self, req: RerankRequest) -> RerankResponse
 
 ```python
 def search(self, req: SearchRequest) -> SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```python
+def ocr(self, req: OcrRequest) -> OcrResponse
+```
+
+###### chat_raw()
+
+**Signature:**
+
+```python
+def chat_raw(self, req: ChatCompletionRequest) -> RawExchange
+```
+
+###### chat_stream_raw()
+
+**Signature:**
+
+```python
+def chat_stream_raw(self, req: ChatCompletionRequest) -> RawStreamExchange
+```
+
+###### embed_raw()
+
+**Signature:**
+
+```python
+def embed_raw(self, req: EmbeddingRequest) -> RawExchange
+```
+
+###### image_generate_raw()
+
+**Signature:**
+
+```python
+def image_generate_raw(self, req: CreateImageRequest) -> RawExchange
+```
+
+###### transcribe_raw()
+
+**Signature:**
+
+```python
+def transcribe_raw(self, req: CreateTranscriptionRequest) -> RawExchange
+```
+
+###### moderate_raw()
+
+**Signature:**
+
+```python
+def moderate_raw(self, req: ModerationRequest) -> RawExchange
+```
+
+###### rerank_raw()
+
+**Signature:**
+
+```python
+def rerank_raw(self, req: RerankRequest) -> RawExchange
+```
+
+###### search_raw()
+
+**Signature:**
+
+```python
+def search_raw(self, req: SearchRequest) -> RawExchange
+```
+
+###### ocr_raw()
+
+**Signature:**
+
+```python
+def ocr_raw(self, req: OcrRequest) -> RawExchange
+```
+
+###### create_file()
+
+**Signature:**
+
+```python
+def create_file(self, req: CreateFileRequest) -> FileObject
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```python
+def retrieve_file(self, file_id: str) -> FileObject
+```
+
+###### delete_file()
+
+**Signature:**
+
+```python
+def delete_file(self, file_id: str) -> DeleteResponse
+```
+
+###### list_files()
+
+**Signature:**
+
+```python
+def list_files(self, query: FileListQuery) -> FileListResponse
+```
+
+###### file_content()
+
+**Signature:**
+
+```python
+def file_content(self, file_id: str) -> bytes
+```
+
+###### create_batch()
+
+**Signature:**
+
+```python
+def create_batch(self, req: CreateBatchRequest) -> BatchObject
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```python
+def retrieve_batch(self, batch_id: str) -> BatchObject
+```
+
+###### list_batches()
+
+**Signature:**
+
+```python
+def list_batches(self, query: BatchListQuery) -> BatchListResponse
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```python
+def cancel_batch(self, batch_id: str) -> BatchObject
+```
+
+###### create_response()
+
+**Signature:**
+
+```python
+def create_response(self, req: CreateResponseRequest) -> ResponseObject
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```python
+def retrieve_response(self, id: str) -> ResponseObject
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```python
+def cancel_response(self, id: str) -> ResponseObject
 ```
 
 
@@ -448,6 +1018,250 @@ def search(self, req: SearchRequest) -> SearchResponse
 | `model` | `str` | — | Model |
 | `usage` | `Usage | None` | `None` | Usage (usage) |
 
+##### Methods
+
+###### estimated_cost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `None` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```python
+def estimated_cost(self) -> float | None
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `float | None` | `None` | Global limit |
+| `model_limits` | `dict[str, float] | None` | `None` | Model limits |
+| `enforcement` | `str | None` | `None` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `int | None` | `None` | Maximum entries |
+| `ttl_seconds` | `int | None` | `None` | Ttl seconds |
+| `backend` | `str | None` | `None` | Backend |
+| `backend_config` | `dict[str, str] | None` | `None` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### create_file()
+
+Upload a file.
+
+**Signature:**
+
+```python
+def create_file(self, req: CreateFileRequest) -> FileObject
+```
+
+###### retrieve_file()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```python
+def retrieve_file(self, file_id: str) -> FileObject
+```
+
+###### delete_file()
+
+Delete a file.
+
+**Signature:**
+
+```python
+def delete_file(self, file_id: str) -> DeleteResponse
+```
+
+###### list_files()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```python
+def list_files(self, query: FileListQuery) -> FileListResponse
+```
+
+###### file_content()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```python
+def file_content(self, file_id: str) -> bytes
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `str | None` | `None` | Api key |
+| `base_url` | `str | None` | `None` | Base url |
+| `model_hint` | `str | None` | `None` | Model hint |
+| `timeout_secs` | `int | None` | `None` | Timeout secs |
+| `max_retries` | `int | None` | `None` | Maximum retries |
+| `extra_headers` | `dict[str, str] | None` | `None` | Extra headers |
+| `cache` | `FileCacheConfig | None` | `None` | Cache (file cache config) |
+| `budget` | `FileBudgetConfig | None` | `None` | Budget (file budget config) |
+| `cooldown_secs` | `int | None` | `None` | Cooldown secs |
+| `rate_limit` | `FileRateLimitConfig | None` | `None` | Rate limit (file rate limit config) |
+| `health_check_secs` | `int | None` | `None` | Health check secs |
+| `cost_tracking` | `bool | None` | `None` | Cost tracking |
+| `tracing` | `bool | None` | `None` | Tracing |
+| `providers` | `list[FileProviderConfig] | None` | `None` | Providers |
+
+##### Methods
+
+###### from_toml_file()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```python
+@staticmethod
+def from_toml_file(path: Path) -> FileConfig
+```
+
+###### from_toml_str()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```python
+@staticmethod
+def from_toml_str(s: str) -> FileConfig
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```python
+@staticmethod
+def discover() -> FileConfig | None
+```
+
+###### into_builder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```python
+def into_builder(self) -> ClientConfigBuilder
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```python
+def providers(self) -> list[FileProviderConfig]
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | — | The name |
+| `base_url` | `str` | — | Base url |
+| `auth_header` | `str | None` | `None` | Auth header |
+| `model_prefixes` | `list[str]` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `int | None` | `None` | Rpm |
+| `tpm` | `int | None` | `None` | Tpm |
+| `window_seconds` | `int | None` | `None` | Window seconds |
+
 
 ---
 
@@ -467,7 +1281,7 @@ def search(self, req: SearchRequest) -> SearchResponse
 |-------|------|---------|-------------|
 | `name` | `str` | — | The name |
 | `description` | `str | None` | `None` | Human-readable description |
-| `parameters` | `dict[str, Any] | None` | `None` | Parameters |
+| `parameters` | `Any | None` | `None` | Parameters |
 | `strict` | `bool | None` | `None` | Strict |
 
 
@@ -526,13 +1340,551 @@ Response containing generated images.
 |-------|------|---------|-------------|
 | `name` | `str` | — | The name |
 | `description` | `str | None` | `None` | Human-readable description |
-| `schema` | `dict[str, Any]` | — | Schema |
+| `schema` | `Any` | — | Schema |
 | `strict` | `bool | None` | `None` | Strict |
 
 
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### is_transient()
+
+Returns `True` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```python
+def is_transient(self) -> bool
+```
+
+###### error_type()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```python
+def error_type(self) -> str
+```
+
+###### from_status()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```python
+@staticmethod
+def from_status(status: int, body: str, retry_after: float) -> LiterLlmError
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```python
+def chat(self, req: ChatCompletionRequest) -> ChatCompletionResponse
+```
+
+###### chat_stream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```python
+def chat_stream(self, req: ChatCompletionRequest) -> BoxStream
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```python
+def embed(self, req: EmbeddingRequest) -> EmbeddingResponse
+```
+
+###### list_models()
+
+List available models.
+
+**Signature:**
+
+```python
+def list_models(self) -> ModelsListResponse
+```
+
+###### image_generate()
+
+Generate an image.
+
+**Signature:**
+
+```python
+def image_generate(self, req: CreateImageRequest) -> ImagesResponse
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```python
+def speech(self, req: CreateSpeechRequest) -> bytes
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```python
+def transcribe(self, req: CreateTranscriptionRequest) -> TranscriptionResponse
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```python
+def moderate(self, req: ModerationRequest) -> ModerationResponse
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```python
+def rerank(self, req: RerankRequest) -> RerankResponse
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```python
+def search(self, req: SearchRequest) -> SearchResponse
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```python
+def ocr(self, req: OcrRequest) -> OcrResponse
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chat_raw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```python
+def chat_raw(self, req: ChatCompletionRequest) -> RawExchange
+```
+
+###### chat_stream_raw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```python
+def chat_stream_raw(self, req: ChatCompletionRequest) -> RawStreamExchange
+```
+
+###### embed_raw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```python
+def embed_raw(self, req: EmbeddingRequest) -> RawExchange
+```
+
+###### image_generate_raw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```python
+def image_generate_raw(self, req: CreateImageRequest) -> RawExchange
+```
+
+###### transcribe_raw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```python
+def transcribe_raw(self, req: CreateTranscriptionRequest) -> RawExchange
+```
+
+###### moderate_raw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```python
+def moderate_raw(self, req: ModerationRequest) -> RawExchange
+```
+
+###### rerank_raw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```python
+def rerank_raw(self, req: RerankRequest) -> RawExchange
+```
+
+###### search_raw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```python
+def search_raw(self, req: SearchRequest) -> RawExchange
+```
+
+###### ocr_raw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```python
+def ocr_raw(self, req: OcrRequest) -> RawExchange
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```python
+@staticmethod
+def new(config: ClientConfig, model_hint: str) -> ManagedClient
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```python
+def inner(self) -> DefaultClient
+```
+
+###### budget_state()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```python
+def budget_state(self) -> BudgetState | None
+```
+
+###### has_middleware()
+
+Return `True` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```python
+def has_middleware(self) -> bool
+```
+
+###### chat()
+
+**Signature:**
+
+```python
+def chat(self, req: ChatCompletionRequest) -> ChatCompletionResponse
+```
+
+###### chat_stream()
+
+**Signature:**
+
+```python
+def chat_stream(self, req: ChatCompletionRequest) -> BoxStream
+```
+
+###### embed()
+
+**Signature:**
+
+```python
+def embed(self, req: EmbeddingRequest) -> EmbeddingResponse
+```
+
+###### list_models()
+
+**Signature:**
+
+```python
+def list_models(self) -> ModelsListResponse
+```
+
+###### image_generate()
+
+**Signature:**
+
+```python
+def image_generate(self, req: CreateImageRequest) -> ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```python
+def speech(self, req: CreateSpeechRequest) -> bytes
+```
+
+###### transcribe()
+
+**Signature:**
+
+```python
+def transcribe(self, req: CreateTranscriptionRequest) -> TranscriptionResponse
+```
+
+###### moderate()
+
+**Signature:**
+
+```python
+def moderate(self, req: ModerationRequest) -> ModerationResponse
+```
+
+###### rerank()
+
+**Signature:**
+
+```python
+def rerank(self, req: RerankRequest) -> RerankResponse
+```
+
+###### search()
+
+**Signature:**
+
+```python
+def search(self, req: SearchRequest) -> SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```python
+def ocr(self, req: OcrRequest) -> OcrResponse
+```
+
+###### create_file()
+
+**Signature:**
+
+```python
+def create_file(self, req: CreateFileRequest) -> FileObject
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```python
+def retrieve_file(self, file_id: str) -> FileObject
+```
+
+###### delete_file()
+
+**Signature:**
+
+```python
+def delete_file(self, file_id: str) -> DeleteResponse
+```
+
+###### list_files()
+
+**Signature:**
+
+```python
+def list_files(self, query: FileListQuery) -> FileListResponse
+```
+
+###### file_content()
+
+**Signature:**
+
+```python
+def file_content(self, file_id: str) -> bytes
+```
+
+###### create_batch()
+
+**Signature:**
+
+```python
+def create_batch(self, req: CreateBatchRequest) -> BatchObject
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```python
+def retrieve_batch(self, batch_id: str) -> BatchObject
+```
+
+###### list_batches()
+
+**Signature:**
+
+```python
+def list_batches(self, query: BatchListQuery) -> BatchListResponse
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```python
+def cancel_batch(self, batch_id: str) -> BatchObject
+```
+
+###### create_response()
+
+**Signature:**
+
+```python
+def create_response(self, req: CreateResponseRequest) -> ResponseObject
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```python
+def retrieve_response(self, id: str) -> ResponseObject
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```python
+def cancel_response(self, id: str) -> ResponseObject
+```
 
 
 ---
@@ -727,7 +2079,7 @@ Response from the rerank endpoint.
 |-------|------|---------|-------------|
 | `id` | `str | None` | `None` | Unique identifier |
 | `results` | `list[RerankResult]` | — | Results |
-| `meta` | `dict[str, Any] | None` | `None` | Meta |
+| `meta` | `Any | None` | `None` | Meta |
 
 
 ---
@@ -752,6 +2104,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `str` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### create_response()
+
+Create a new response.
+
+**Signature:**
+
+```python
+def create_response(self, req: CreateResponseRequest) -> ResponseObject
+```
+
+###### retrieve_response()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```python
+def retrieve_response(self, id: str) -> ResponseObject
+```
+
+###### cancel_response()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```python
+def cancel_response(self, id: str) -> ResponseObject
+```
 
 
 ---
@@ -1189,3 +2580,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-ruby.md
+++ b/docs/reference/api-ruby.md
@@ -135,6 +135,20 @@ def self.unregister_custom_provider(name)
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `String` | — | Message |
+| `error_type` | `String` | — | Error type |
+| `param` | `String?` | `nil` | Param |
+| `code` | `String?` | `nil` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ def self.unregister_custom_provider(name)
 |-------|------|---------|-------------|
 | `data` | `String` | — | Base64-encoded audio data. |
 | `format` | `String` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### create_batch()
+
+Create a new batch job.
+
+**Signature:**
+
+```ruby
+def create_batch(req)
+```
+
+###### retrieve_batch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```ruby
+def retrieve_batch(batch_id)
+```
+
+###### list_batches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```ruby
+def list_batches(query)
+```
+
+###### cancel_batch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```ruby
+def cancel_batch(batch_id)
+```
 
 
 ---
@@ -215,6 +278,22 @@ def self.unregister_custom_provider(name)
 | `system_fingerprint` | `String?` | `nil` | System fingerprint |
 | `service_tier` | `String?` | `nil` | Service tier |
 
+##### Methods
+
+###### estimated_cost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `nil` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```ruby
+def estimated_cost()
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ def self.unregister_custom_provider(name)
 | `index` | `Integer` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finish_reason` | `FinishReason?` | `nil` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String` | — | API key for authentication (stored as a secret). |
+| `base_url` | `String?` | `nil` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `Float` | — | Request timeout. |
+| `max_retries` | `Integer` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `CredentialProvider?` | `nil` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `Boolean` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```ruby
+def headers()
+```
+
+###### fmt()
+
+**Signature:**
+
+```ruby
+def fmt(f)
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### from_env()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```ruby
+def self.from_env()
+```
+
+###### load_env()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```ruby
+def load_env(enabled)
+```
+
+###### base_url()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```ruby
+def base_url(url)
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```ruby
+def timeout(timeout)
+```
+
+###### max_retries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```ruby
+def max_retries(retries)
+```
+
+###### credential_provider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```ruby
+def credential_provider(provider)
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```ruby
+def header(key, value)
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```ruby
+def cache(config)
+```
+
+###### cache_store()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```ruby
+def cache_store(store)
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```ruby
+def budget(config)
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```ruby
+def hook(hook)
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```ruby
+def hooks(hooks)
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```ruby
+def cooldown(duration)
+```
+
+###### rate_limit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```ruby
+def rate_limit(config)
+```
+
+###### health_check()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```ruby
+def health_check(interval)
+```
+
+###### cost_tracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```ruby
+def cost_tracking(enabled)
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```ruby
+def tracing(enabled)
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```ruby
+def build()
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `nil` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```ruby
+def self.new(config, model_hint)
+```
+
 ###### chat()
 
 **Signature:**
@@ -360,6 +744,14 @@ def list_models()
 def image_generate(req)
 ```
 
+###### speech()
+
+**Signature:**
+
+```ruby
+def speech(req)
+```
+
 ###### transcribe()
 
 **Signature:**
@@ -390,6 +782,182 @@ def rerank(req)
 
 ```ruby
 def search(req)
+```
+
+###### ocr()
+
+**Signature:**
+
+```ruby
+def ocr(req)
+```
+
+###### chat_raw()
+
+**Signature:**
+
+```ruby
+def chat_raw(req)
+```
+
+###### chat_stream_raw()
+
+**Signature:**
+
+```ruby
+def chat_stream_raw(req)
+```
+
+###### embed_raw()
+
+**Signature:**
+
+```ruby
+def embed_raw(req)
+```
+
+###### image_generate_raw()
+
+**Signature:**
+
+```ruby
+def image_generate_raw(req)
+```
+
+###### transcribe_raw()
+
+**Signature:**
+
+```ruby
+def transcribe_raw(req)
+```
+
+###### moderate_raw()
+
+**Signature:**
+
+```ruby
+def moderate_raw(req)
+```
+
+###### rerank_raw()
+
+**Signature:**
+
+```ruby
+def rerank_raw(req)
+```
+
+###### search_raw()
+
+**Signature:**
+
+```ruby
+def search_raw(req)
+```
+
+###### ocr_raw()
+
+**Signature:**
+
+```ruby
+def ocr_raw(req)
+```
+
+###### create_file()
+
+**Signature:**
+
+```ruby
+def create_file(req)
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```ruby
+def retrieve_file(file_id)
+```
+
+###### delete_file()
+
+**Signature:**
+
+```ruby
+def delete_file(file_id)
+```
+
+###### list_files()
+
+**Signature:**
+
+```ruby
+def list_files(query)
+```
+
+###### file_content()
+
+**Signature:**
+
+```ruby
+def file_content(file_id)
+```
+
+###### create_batch()
+
+**Signature:**
+
+```ruby
+def create_batch(req)
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```ruby
+def retrieve_batch(batch_id)
+```
+
+###### list_batches()
+
+**Signature:**
+
+```ruby
+def list_batches(query)
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```ruby
+def cancel_batch(batch_id)
+```
+
+###### create_response()
+
+**Signature:**
+
+```ruby
+def create_response(req)
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```ruby
+def retrieve_response(id)
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```ruby
+def cancel_response(id)
 ```
 
 
@@ -447,6 +1015,247 @@ def search(req)
 | `data` | `Array<EmbeddingObject>` | — | Data |
 | `model` | `String` | — | Model |
 | `usage` | `Usage?` | `nil` | Usage (usage) |
+
+##### Methods
+
+###### estimated_cost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `nil` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```ruby
+def estimated_cost()
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `Float?` | `nil` | Global limit |
+| `model_limits` | `Hash{String=>Float}?` | `nil` | Model limits |
+| `enforcement` | `String?` | `nil` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `Integer?` | `nil` | Maximum entries |
+| `ttl_seconds` | `Integer?` | `nil` | Ttl seconds |
+| `backend` | `String?` | `nil` | Backend |
+| `backend_config` | `Hash{String=>String}?` | `nil` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### create_file()
+
+Upload a file.
+
+**Signature:**
+
+```ruby
+def create_file(req)
+```
+
+###### retrieve_file()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```ruby
+def retrieve_file(file_id)
+```
+
+###### delete_file()
+
+Delete a file.
+
+**Signature:**
+
+```ruby
+def delete_file(file_id)
+```
+
+###### list_files()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```ruby
+def list_files(query)
+```
+
+###### file_content()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```ruby
+def file_content(file_id)
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String?` | `nil` | Api key |
+| `base_url` | `String?` | `nil` | Base url |
+| `model_hint` | `String?` | `nil` | Model hint |
+| `timeout_secs` | `Integer?` | `nil` | Timeout secs |
+| `max_retries` | `Integer?` | `nil` | Maximum retries |
+| `extra_headers` | `Hash{String=>String}?` | `nil` | Extra headers |
+| `cache` | `FileCacheConfig?` | `nil` | Cache (file cache config) |
+| `budget` | `FileBudgetConfig?` | `nil` | Budget (file budget config) |
+| `cooldown_secs` | `Integer?` | `nil` | Cooldown secs |
+| `rate_limit` | `FileRateLimitConfig?` | `nil` | Rate limit (file rate limit config) |
+| `health_check_secs` | `Integer?` | `nil` | Health check secs |
+| `cost_tracking` | `Boolean?` | `nil` | Cost tracking |
+| `tracing` | `Boolean?` | `nil` | Tracing |
+| `providers` | `Array<FileProviderConfig>?` | `nil` | Providers |
+
+##### Methods
+
+###### from_toml_file()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```ruby
+def self.from_toml_file(path)
+```
+
+###### from_toml_str()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```ruby
+def self.from_toml_str(s)
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```ruby
+def self.discover()
+```
+
+###### into_builder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```ruby
+def into_builder()
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```ruby
+def providers()
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `String` | — | The name |
+| `base_url` | `String` | — | Base url |
+| `auth_header` | `String?` | `nil` | Auth header |
+| `model_prefixes` | `Array<String>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `Integer?` | `nil` | Rpm |
+| `tpm` | `Integer?` | `nil` | Tpm |
+| `window_seconds` | `Integer?` | `nil` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### is_transient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```ruby
+def is_transient()
+```
+
+###### error_type()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```ruby
+def error_type()
+```
+
+###### from_status()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```ruby
+def self.from_status(status, body, retry_after)
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```ruby
+def chat(req)
+```
+
+###### chat_stream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```ruby
+def chat_stream(req)
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```ruby
+def embed(req)
+```
+
+###### list_models()
+
+List available models.
+
+**Signature:**
+
+```ruby
+def list_models()
+```
+
+###### image_generate()
+
+Generate an image.
+
+**Signature:**
+
+```ruby
+def image_generate(req)
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```ruby
+def speech(req)
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```ruby
+def transcribe(req)
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```ruby
+def moderate(req)
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```ruby
+def rerank(req)
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```ruby
+def search(req)
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```ruby
+def ocr(req)
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chat_raw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```ruby
+def chat_raw(req)
+```
+
+###### chat_stream_raw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```ruby
+def chat_stream_raw(req)
+```
+
+###### embed_raw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def embed_raw(req)
+```
+
+###### image_generate_raw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def image_generate_raw(req)
+```
+
+###### transcribe_raw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def transcribe_raw(req)
+```
+
+###### moderate_raw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def moderate_raw(req)
+```
+
+###### rerank_raw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def rerank_raw(req)
+```
+
+###### search_raw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def search_raw(req)
+```
+
+###### ocr_raw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```ruby
+def ocr_raw(req)
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```ruby
+def self.new(config, model_hint)
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```ruby
+def inner()
+```
+
+###### budget_state()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```ruby
+def budget_state()
+```
+
+###### has_middleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```ruby
+def has_middleware()
+```
+
+###### chat()
+
+**Signature:**
+
+```ruby
+def chat(req)
+```
+
+###### chat_stream()
+
+**Signature:**
+
+```ruby
+def chat_stream(req)
+```
+
+###### embed()
+
+**Signature:**
+
+```ruby
+def embed(req)
+```
+
+###### list_models()
+
+**Signature:**
+
+```ruby
+def list_models()
+```
+
+###### image_generate()
+
+**Signature:**
+
+```ruby
+def image_generate(req)
+```
+
+###### speech()
+
+**Signature:**
+
+```ruby
+def speech(req)
+```
+
+###### transcribe()
+
+**Signature:**
+
+```ruby
+def transcribe(req)
+```
+
+###### moderate()
+
+**Signature:**
+
+```ruby
+def moderate(req)
+```
+
+###### rerank()
+
+**Signature:**
+
+```ruby
+def rerank(req)
+```
+
+###### search()
+
+**Signature:**
+
+```ruby
+def search(req)
+```
+
+###### ocr()
+
+**Signature:**
+
+```ruby
+def ocr(req)
+```
+
+###### create_file()
+
+**Signature:**
+
+```ruby
+def create_file(req)
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```ruby
+def retrieve_file(file_id)
+```
+
+###### delete_file()
+
+**Signature:**
+
+```ruby
+def delete_file(file_id)
+```
+
+###### list_files()
+
+**Signature:**
+
+```ruby
+def list_files(query)
+```
+
+###### file_content()
+
+**Signature:**
+
+```ruby
+def file_content(file_id)
+```
+
+###### create_batch()
+
+**Signature:**
+
+```ruby
+def create_batch(req)
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```ruby
+def retrieve_batch(batch_id)
+```
+
+###### list_batches()
+
+**Signature:**
+
+```ruby
+def list_batches(query)
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```ruby
+def cancel_batch(batch_id)
+```
+
+###### create_response()
+
+**Signature:**
+
+```ruby
+def create_response(req)
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```ruby
+def retrieve_response(id)
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```ruby
+def cancel_response(id)
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `String` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `OcrDocument` | — | The document to process. |
-| `pages` | `Array<Integer>?` | `nil` | Specific pages to process (1-indexed). `nil` means all pages. |
+| `pages` | `Array<Integer>?` | `nil` | Specific pages to process (1-indexed). `None` means all pages. |
 | `include_image_base64` | `Boolean?` | `nil` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `String` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### create_response()
+
+Create a new response.
+
+**Signature:**
+
+```ruby
+def create_response(req)
+```
+
+###### retrieve_response()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```ruby
+def retrieve_response(id)
+```
+
+###### cancel_response()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```ruby
+def cancel_response(id)
+```
 
 
 ---
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-rust.md
+++ b/docs/reference/api-rust.md
@@ -135,6 +135,20 @@ pub fn unregister_custom_provider(name: &str) -> Result<bool, Error>
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `String` | — | Message |
+| `error_type` | `String` | — | Error type |
+| `param` | `Option<String>` | `None` | Param |
+| `code` | `Option<String>` | `None` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ pub fn unregister_custom_provider(name: &str) -> Result<bool, Error>
 |-------|------|---------|-------------|
 | `data` | `String` | — | Base64-encoded audio data. |
 | `format` | `String` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### create_batch()
+
+Create a new batch job.
+
+**Signature:**
+
+```rust
+pub fn create_batch(&self, req: CreateBatchRequest) -> BatchObject
+```
+
+###### retrieve_batch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```rust
+pub fn retrieve_batch(&self, batch_id: String) -> BatchObject
+```
+
+###### list_batches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```rust
+pub fn list_batches(&self, query: Option<BatchListQuery>) -> BatchListResponse
+```
+
+###### cancel_batch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```rust
+pub fn cancel_batch(&self, batch_id: String) -> BatchObject
+```
 
 
 ---
@@ -215,6 +278,22 @@ pub fn unregister_custom_provider(name: &str) -> Result<bool, Error>
 | `system_fingerprint` | `Option<String>` | `Default::default()` | System fingerprint |
 | `service_tier` | `Option<String>` | `Default::default()` | Service tier |
 
+##### Methods
+
+###### estimated_cost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `None` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```rust
+pub fn estimated_cost(&self) -> Option<f64>
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ pub fn unregister_custom_provider(name: &str) -> Result<bool, Error>
 | `index` | `u32` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finish_reason` | `Option<FinishReason>` | `Default::default()` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String` | — | API key for authentication (stored as a secret). |
+| `base_url` | `Option<String>` | `None` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `std::time::Duration` | — | Request timeout. |
+| `max_retries` | `u32` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `Option<CredentialProvider>` | `None` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```rust
+pub fn headers(&self) -> Vec<(String, String)>
+```
+
+###### fmt()
+
+**Signature:**
+
+```rust
+pub fn fmt(&self, f: Formatter) -> Unknown
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### from_env()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```rust
+pub fn from_env() -> ClientConfigBuilder
+```
+
+###### load_env()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```rust
+pub fn load_env(&self, enabled: bool) -> ClientConfigBuilder
+```
+
+###### base_url()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```rust
+pub fn base_url(&self, url: String) -> ClientConfigBuilder
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```rust
+pub fn timeout(&self, timeout: std::time::Duration) -> ClientConfigBuilder
+```
+
+###### max_retries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```rust
+pub fn max_retries(&self, retries: u32) -> ClientConfigBuilder
+```
+
+###### credential_provider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```rust
+pub fn credential_provider(&self, provider: CredentialProvider) -> ClientConfigBuilder
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```rust
+pub fn header(&self, key: String, value: String) -> ClientConfigBuilder
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```rust
+pub fn cache(&self, config: CacheConfig) -> ClientConfigBuilder
+```
+
+###### cache_store()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```rust
+pub fn cache_store(&self, store: CacheStore) -> ClientConfigBuilder
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```rust
+pub fn budget(&self, config: BudgetConfig) -> ClientConfigBuilder
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```rust
+pub fn hook(&self, hook: LlmHook) -> ClientConfigBuilder
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```rust
+pub fn hooks(&self, hooks: Vec<LlmHook>) -> ClientConfigBuilder
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```rust
+pub fn cooldown(&self, duration: std::time::Duration) -> ClientConfigBuilder
+```
+
+###### rate_limit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```rust
+pub fn rate_limit(&self, config: RateLimitConfig) -> ClientConfigBuilder
+```
+
+###### health_check()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```rust
+pub fn health_check(&self, interval: std::time::Duration) -> ClientConfigBuilder
+```
+
+###### cost_tracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```rust
+pub fn cost_tracking(&self, enabled: bool) -> ClientConfigBuilder
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```rust
+pub fn tracing(&self, enabled: bool) -> ClientConfigBuilder
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```rust
+pub fn build(&self) -> ClientConfig
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `None` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```rust
+pub fn new(config: ClientConfig, model_hint: Option<String>) -> DefaultClient
+```
+
 ###### chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ pub fn chat(&self, req: ChatCompletionRequest) -> ChatCompletionResponse
 **Signature:**
 
 ```rust
-pub fn chat_stream(&self, req: ChatCompletionRequest) -> String
+pub fn chat_stream(&self, req: ChatCompletionRequest) -> BoxStream
 ```
 
 ###### embed()
@@ -358,6 +742,14 @@ pub fn list_models(&self) -> ModelsListResponse
 
 ```rust
 pub fn image_generate(&self, req: CreateImageRequest) -> ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```rust
+pub fn speech(&self, req: CreateSpeechRequest) -> Vec<u8>
 ```
 
 ###### transcribe()
@@ -390,6 +782,182 @@ pub fn rerank(&self, req: RerankRequest) -> RerankResponse
 
 ```rust
 pub fn search(&self, req: SearchRequest) -> SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```rust
+pub fn ocr(&self, req: OcrRequest) -> OcrResponse
+```
+
+###### chat_raw()
+
+**Signature:**
+
+```rust
+pub fn chat_raw(&self, req: ChatCompletionRequest) -> RawExchange
+```
+
+###### chat_stream_raw()
+
+**Signature:**
+
+```rust
+pub fn chat_stream_raw(&self, req: ChatCompletionRequest) -> RawStreamExchange
+```
+
+###### embed_raw()
+
+**Signature:**
+
+```rust
+pub fn embed_raw(&self, req: EmbeddingRequest) -> RawExchange
+```
+
+###### image_generate_raw()
+
+**Signature:**
+
+```rust
+pub fn image_generate_raw(&self, req: CreateImageRequest) -> RawExchange
+```
+
+###### transcribe_raw()
+
+**Signature:**
+
+```rust
+pub fn transcribe_raw(&self, req: CreateTranscriptionRequest) -> RawExchange
+```
+
+###### moderate_raw()
+
+**Signature:**
+
+```rust
+pub fn moderate_raw(&self, req: ModerationRequest) -> RawExchange
+```
+
+###### rerank_raw()
+
+**Signature:**
+
+```rust
+pub fn rerank_raw(&self, req: RerankRequest) -> RawExchange
+```
+
+###### search_raw()
+
+**Signature:**
+
+```rust
+pub fn search_raw(&self, req: SearchRequest) -> RawExchange
+```
+
+###### ocr_raw()
+
+**Signature:**
+
+```rust
+pub fn ocr_raw(&self, req: OcrRequest) -> RawExchange
+```
+
+###### create_file()
+
+**Signature:**
+
+```rust
+pub fn create_file(&self, req: CreateFileRequest) -> FileObject
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```rust
+pub fn retrieve_file(&self, file_id: String) -> FileObject
+```
+
+###### delete_file()
+
+**Signature:**
+
+```rust
+pub fn delete_file(&self, file_id: String) -> DeleteResponse
+```
+
+###### list_files()
+
+**Signature:**
+
+```rust
+pub fn list_files(&self, query: Option<FileListQuery>) -> FileListResponse
+```
+
+###### file_content()
+
+**Signature:**
+
+```rust
+pub fn file_content(&self, file_id: String) -> Vec<u8>
+```
+
+###### create_batch()
+
+**Signature:**
+
+```rust
+pub fn create_batch(&self, req: CreateBatchRequest) -> BatchObject
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```rust
+pub fn retrieve_batch(&self, batch_id: String) -> BatchObject
+```
+
+###### list_batches()
+
+**Signature:**
+
+```rust
+pub fn list_batches(&self, query: Option<BatchListQuery>) -> BatchListResponse
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```rust
+pub fn cancel_batch(&self, batch_id: String) -> BatchObject
+```
+
+###### create_response()
+
+**Signature:**
+
+```rust
+pub fn create_response(&self, req: CreateResponseRequest) -> ResponseObject
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```rust
+pub fn retrieve_response(&self, id: String) -> ResponseObject
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```rust
+pub fn cancel_response(&self, id: String) -> ResponseObject
 ```
 
 
@@ -447,6 +1015,247 @@ pub fn search(&self, req: SearchRequest) -> SearchResponse
 | `data` | `Vec<EmbeddingObject>` | — | Data |
 | `model` | `String` | — | Model |
 | `usage` | `Option<Usage>` | `None` | Usage (usage) |
+
+##### Methods
+
+###### estimated_cost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `None` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```rust
+pub fn estimated_cost(&self) -> Option<f64>
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `Option<f64>` | `None` | Global limit |
+| `model_limits` | `Option<HashMap<String, f64>>` | `None` | Model limits |
+| `enforcement` | `Option<String>` | `None` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `Option<usize>` | `None` | Maximum entries |
+| `ttl_seconds` | `Option<u64>` | `None` | Ttl seconds |
+| `backend` | `Option<String>` | `None` | Backend |
+| `backend_config` | `Option<HashMap<String, String>>` | `None` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### create_file()
+
+Upload a file.
+
+**Signature:**
+
+```rust
+pub fn create_file(&self, req: CreateFileRequest) -> FileObject
+```
+
+###### retrieve_file()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```rust
+pub fn retrieve_file(&self, file_id: String) -> FileObject
+```
+
+###### delete_file()
+
+Delete a file.
+
+**Signature:**
+
+```rust
+pub fn delete_file(&self, file_id: String) -> DeleteResponse
+```
+
+###### list_files()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```rust
+pub fn list_files(&self, query: Option<FileListQuery>) -> FileListResponse
+```
+
+###### file_content()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```rust
+pub fn file_content(&self, file_id: String) -> Vec<u8>
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `Option<String>` | `None` | Api key |
+| `base_url` | `Option<String>` | `None` | Base url |
+| `model_hint` | `Option<String>` | `None` | Model hint |
+| `timeout_secs` | `Option<u64>` | `None` | Timeout secs |
+| `max_retries` | `Option<u32>` | `None` | Maximum retries |
+| `extra_headers` | `Option<HashMap<String, String>>` | `None` | Extra headers |
+| `cache` | `Option<FileCacheConfig>` | `None` | Cache (file cache config) |
+| `budget` | `Option<FileBudgetConfig>` | `None` | Budget (file budget config) |
+| `cooldown_secs` | `Option<u64>` | `None` | Cooldown secs |
+| `rate_limit` | `Option<FileRateLimitConfig>` | `None` | Rate limit (file rate limit config) |
+| `health_check_secs` | `Option<u64>` | `None` | Health check secs |
+| `cost_tracking` | `Option<bool>` | `None` | Cost tracking |
+| `tracing` | `Option<bool>` | `None` | Tracing |
+| `providers` | `Option<Vec<FileProviderConfig>>` | `None` | Providers |
+
+##### Methods
+
+###### from_toml_file()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```rust
+pub fn from_toml_file(path: Path) -> FileConfig
+```
+
+###### from_toml_str()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```rust
+pub fn from_toml_str(s: String) -> FileConfig
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```rust
+pub fn discover() -> Option<FileConfig>
+```
+
+###### into_builder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```rust
+pub fn into_builder(&self) -> ClientConfigBuilder
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```rust
+pub fn providers(&self) -> Vec<FileProviderConfig>
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `String` | — | The name |
+| `base_url` | `String` | — | Base url |
+| `auth_header` | `Option<String>` | `None` | Auth header |
+| `model_prefixes` | `Vec<String>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `Option<u32>` | `None` | Rpm |
+| `tpm` | `Option<u64>` | `None` | Tpm |
+| `window_seconds` | `Option<u64>` | `None` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### is_transient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```rust
+pub fn is_transient(&self) -> bool
+```
+
+###### error_type()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```rust
+pub fn error_type(&self) -> String
+```
+
+###### from_status()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```rust
+pub fn from_status(status: u16, body: String, retry_after: Option<std::time::Duration>) -> LiterLlmError
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```rust
+pub fn chat(&self, req: ChatCompletionRequest) -> ChatCompletionResponse
+```
+
+###### chat_stream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```rust
+pub fn chat_stream(&self, req: ChatCompletionRequest) -> BoxStream
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```rust
+pub fn embed(&self, req: EmbeddingRequest) -> EmbeddingResponse
+```
+
+###### list_models()
+
+List available models.
+
+**Signature:**
+
+```rust
+pub fn list_models(&self) -> ModelsListResponse
+```
+
+###### image_generate()
+
+Generate an image.
+
+**Signature:**
+
+```rust
+pub fn image_generate(&self, req: CreateImageRequest) -> ImagesResponse
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```rust
+pub fn speech(&self, req: CreateSpeechRequest) -> Vec<u8>
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```rust
+pub fn transcribe(&self, req: CreateTranscriptionRequest) -> TranscriptionResponse
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```rust
+pub fn moderate(&self, req: ModerationRequest) -> ModerationResponse
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```rust
+pub fn rerank(&self, req: RerankRequest) -> RerankResponse
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```rust
+pub fn search(&self, req: SearchRequest) -> SearchResponse
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```rust
+pub fn ocr(&self, req: OcrRequest) -> OcrResponse
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chat_raw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```rust
+pub fn chat_raw(&self, req: ChatCompletionRequest) -> RawExchange
+```
+
+###### chat_stream_raw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```rust
+pub fn chat_stream_raw(&self, req: ChatCompletionRequest) -> RawStreamExchange
+```
+
+###### embed_raw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn embed_raw(&self, req: EmbeddingRequest) -> RawExchange
+```
+
+###### image_generate_raw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn image_generate_raw(&self, req: CreateImageRequest) -> RawExchange
+```
+
+###### transcribe_raw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn transcribe_raw(&self, req: CreateTranscriptionRequest) -> RawExchange
+```
+
+###### moderate_raw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn moderate_raw(&self, req: ModerationRequest) -> RawExchange
+```
+
+###### rerank_raw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn rerank_raw(&self, req: RerankRequest) -> RawExchange
+```
+
+###### search_raw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn search_raw(&self, req: SearchRequest) -> RawExchange
+```
+
+###### ocr_raw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```rust
+pub fn ocr_raw(&self, req: OcrRequest) -> RawExchange
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```rust
+pub fn new(config: ClientConfig, model_hint: Option<String>) -> ManagedClient
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```rust
+pub fn inner(&self) -> DefaultClient
+```
+
+###### budget_state()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```rust
+pub fn budget_state(&self) -> Option<BudgetState>
+```
+
+###### has_middleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```rust
+pub fn has_middleware(&self) -> bool
+```
+
+###### chat()
+
+**Signature:**
+
+```rust
+pub fn chat(&self, req: ChatCompletionRequest) -> ChatCompletionResponse
+```
+
+###### chat_stream()
+
+**Signature:**
+
+```rust
+pub fn chat_stream(&self, req: ChatCompletionRequest) -> BoxStream
+```
+
+###### embed()
+
+**Signature:**
+
+```rust
+pub fn embed(&self, req: EmbeddingRequest) -> EmbeddingResponse
+```
+
+###### list_models()
+
+**Signature:**
+
+```rust
+pub fn list_models(&self) -> ModelsListResponse
+```
+
+###### image_generate()
+
+**Signature:**
+
+```rust
+pub fn image_generate(&self, req: CreateImageRequest) -> ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```rust
+pub fn speech(&self, req: CreateSpeechRequest) -> Vec<u8>
+```
+
+###### transcribe()
+
+**Signature:**
+
+```rust
+pub fn transcribe(&self, req: CreateTranscriptionRequest) -> TranscriptionResponse
+```
+
+###### moderate()
+
+**Signature:**
+
+```rust
+pub fn moderate(&self, req: ModerationRequest) -> ModerationResponse
+```
+
+###### rerank()
+
+**Signature:**
+
+```rust
+pub fn rerank(&self, req: RerankRequest) -> RerankResponse
+```
+
+###### search()
+
+**Signature:**
+
+```rust
+pub fn search(&self, req: SearchRequest) -> SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```rust
+pub fn ocr(&self, req: OcrRequest) -> OcrResponse
+```
+
+###### create_file()
+
+**Signature:**
+
+```rust
+pub fn create_file(&self, req: CreateFileRequest) -> FileObject
+```
+
+###### retrieve_file()
+
+**Signature:**
+
+```rust
+pub fn retrieve_file(&self, file_id: String) -> FileObject
+```
+
+###### delete_file()
+
+**Signature:**
+
+```rust
+pub fn delete_file(&self, file_id: String) -> DeleteResponse
+```
+
+###### list_files()
+
+**Signature:**
+
+```rust
+pub fn list_files(&self, query: Option<FileListQuery>) -> FileListResponse
+```
+
+###### file_content()
+
+**Signature:**
+
+```rust
+pub fn file_content(&self, file_id: String) -> Vec<u8>
+```
+
+###### create_batch()
+
+**Signature:**
+
+```rust
+pub fn create_batch(&self, req: CreateBatchRequest) -> BatchObject
+```
+
+###### retrieve_batch()
+
+**Signature:**
+
+```rust
+pub fn retrieve_batch(&self, batch_id: String) -> BatchObject
+```
+
+###### list_batches()
+
+**Signature:**
+
+```rust
+pub fn list_batches(&self, query: Option<BatchListQuery>) -> BatchListResponse
+```
+
+###### cancel_batch()
+
+**Signature:**
+
+```rust
+pub fn cancel_batch(&self, batch_id: String) -> BatchObject
+```
+
+###### create_response()
+
+**Signature:**
+
+```rust
+pub fn create_response(&self, req: CreateResponseRequest) -> ResponseObject
+```
+
+###### retrieve_response()
+
+**Signature:**
+
+```rust
+pub fn retrieve_response(&self, id: String) -> ResponseObject
+```
+
+###### cancel_response()
+
+**Signature:**
+
+```rust
+pub fn cancel_response(&self, id: String) -> ResponseObject
+```
 
 
 ---
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `String` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### create_response()
+
+Create a new response.
+
+**Signature:**
+
+```rust
+pub fn create_response(&self, req: CreateResponseRequest) -> ResponseObject
+```
+
+###### retrieve_response()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```rust
+pub fn retrieve_response(&self, id: String) -> ResponseObject
+```
+
+###### cancel_response()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```rust
+pub fn cancel_response(&self, id: String) -> ResponseObject
+```
 
 
 ---
@@ -1187,3 +2571,4 @@ All errors that can occur when using `liter-llm`.
 
 
 ---
+

--- a/docs/reference/api-typescript.md
+++ b/docs/reference/api-typescript.md
@@ -135,6 +135,20 @@ function unregisterCustomProvider(name: string): boolean
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `string` | — | Message |
+| `errorType` | `string` | — | Error type |
+| `param` | `string | null` | `null` | Param |
+| `code` | `string | null` | `null` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ function unregisterCustomProvider(name: string): boolean
 |-------|------|---------|-------------|
 | `data` | `string` | — | Base64-encoded audio data. |
 | `format` | `string` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### createBatch()
+
+Create a new batch job.
+
+**Signature:**
+
+```typescript
+createBatch(req: CreateBatchRequest): BatchObject
+```
+
+###### retrieveBatch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```typescript
+retrieveBatch(batchId: string): BatchObject
+```
+
+###### listBatches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```typescript
+listBatches(query: BatchListQuery): BatchListResponse
+```
+
+###### cancelBatch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```typescript
+cancelBatch(batchId: string): BatchObject
+```
 
 
 ---
@@ -215,6 +278,22 @@ function unregisterCustomProvider(name: string): boolean
 | `systemFingerprint` | `string | null` | `null` | System fingerprint |
 | `serviceTier` | `string | null` | `null` | Service tier |
 
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```typescript
+estimatedCost(): number | null
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ function unregisterCustomProvider(name: string): boolean
 | `index` | `number` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finishReason` | `FinishReason | null` | `null` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `string` | — | API key for authentication (stored as a secret). |
+| `baseUrl` | `string | null` | `null` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `number` | — | Request timeout. |
+| `maxRetries` | `number` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credentialProvider` | `CredentialProvider | null` | `null` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `loadEnv` | `boolean` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```typescript
+headers(): Array<[string, string]>
+```
+
+###### fmt()
+
+**Signature:**
+
+```typescript
+fmt(f: Formatter): Unknown
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### fromEnv()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```typescript
+static fromEnv(): ClientConfigBuilder
+```
+
+###### loadEnv()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```typescript
+loadEnv(enabled: boolean): ClientConfigBuilder
+```
+
+###### baseUrl()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```typescript
+baseUrl(url: string): ClientConfigBuilder
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```typescript
+timeout(timeout: number): ClientConfigBuilder
+```
+
+###### maxRetries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```typescript
+maxRetries(retries: number): ClientConfigBuilder
+```
+
+###### credentialProvider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```typescript
+credentialProvider(provider: CredentialProvider): ClientConfigBuilder
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```typescript
+header(key: string, value: string): ClientConfigBuilder
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```typescript
+cache(config: CacheConfig): ClientConfigBuilder
+```
+
+###### cacheStore()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```typescript
+cacheStore(store: CacheStore): ClientConfigBuilder
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```typescript
+budget(config: BudgetConfig): ClientConfigBuilder
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```typescript
+hook(hook: LlmHook): ClientConfigBuilder
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```typescript
+hooks(hooks: Array<LlmHook>): ClientConfigBuilder
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```typescript
+cooldown(duration: number): ClientConfigBuilder
+```
+
+###### rateLimit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```typescript
+rateLimit(config: RateLimitConfig): ClientConfigBuilder
+```
+
+###### healthCheck()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```typescript
+healthCheck(interval: number): ClientConfigBuilder
+```
+
+###### costTracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```typescript
+costTracking(enabled: boolean): ClientConfigBuilder
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```typescript
+tracing(enabled: boolean): ClientConfigBuilder
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```typescript
+build(): ClientConfig
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `null` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```typescript
+static new(config: ClientConfig, modelHint: string): DefaultClient
+```
+
 ###### chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ chat(req: ChatCompletionRequest): ChatCompletionResponse
 **Signature:**
 
 ```typescript
-chatStream(req: ChatCompletionRequest): string
+chatStream(req: ChatCompletionRequest): BoxStream
 ```
 
 ###### embed()
@@ -358,6 +742,14 @@ listModels(): ModelsListResponse
 
 ```typescript
 imageGenerate(req: CreateImageRequest): ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```typescript
+speech(req: CreateSpeechRequest): Buffer
 ```
 
 ###### transcribe()
@@ -390,6 +782,182 @@ rerank(req: RerankRequest): RerankResponse
 
 ```typescript
 search(req: SearchRequest): SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```typescript
+ocr(req: OcrRequest): OcrResponse
+```
+
+###### chatRaw()
+
+**Signature:**
+
+```typescript
+chatRaw(req: ChatCompletionRequest): RawExchange
+```
+
+###### chatStreamRaw()
+
+**Signature:**
+
+```typescript
+chatStreamRaw(req: ChatCompletionRequest): RawStreamExchange
+```
+
+###### embedRaw()
+
+**Signature:**
+
+```typescript
+embedRaw(req: EmbeddingRequest): RawExchange
+```
+
+###### imageGenerateRaw()
+
+**Signature:**
+
+```typescript
+imageGenerateRaw(req: CreateImageRequest): RawExchange
+```
+
+###### transcribeRaw()
+
+**Signature:**
+
+```typescript
+transcribeRaw(req: CreateTranscriptionRequest): RawExchange
+```
+
+###### moderateRaw()
+
+**Signature:**
+
+```typescript
+moderateRaw(req: ModerationRequest): RawExchange
+```
+
+###### rerankRaw()
+
+**Signature:**
+
+```typescript
+rerankRaw(req: RerankRequest): RawExchange
+```
+
+###### searchRaw()
+
+**Signature:**
+
+```typescript
+searchRaw(req: SearchRequest): RawExchange
+```
+
+###### ocrRaw()
+
+**Signature:**
+
+```typescript
+ocrRaw(req: OcrRequest): RawExchange
+```
+
+###### createFile()
+
+**Signature:**
+
+```typescript
+createFile(req: CreateFileRequest): FileObject
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```typescript
+retrieveFile(fileId: string): FileObject
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```typescript
+deleteFile(fileId: string): DeleteResponse
+```
+
+###### listFiles()
+
+**Signature:**
+
+```typescript
+listFiles(query: FileListQuery): FileListResponse
+```
+
+###### fileContent()
+
+**Signature:**
+
+```typescript
+fileContent(fileId: string): Buffer
+```
+
+###### createBatch()
+
+**Signature:**
+
+```typescript
+createBatch(req: CreateBatchRequest): BatchObject
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```typescript
+retrieveBatch(batchId: string): BatchObject
+```
+
+###### listBatches()
+
+**Signature:**
+
+```typescript
+listBatches(query: BatchListQuery): BatchListResponse
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```typescript
+cancelBatch(batchId: string): BatchObject
+```
+
+###### createResponse()
+
+**Signature:**
+
+```typescript
+createResponse(req: CreateResponseRequest): ResponseObject
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```typescript
+retrieveResponse(id: string): ResponseObject
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```typescript
+cancelResponse(id: string): ResponseObject
 ```
 
 
@@ -447,6 +1015,247 @@ search(req: SearchRequest): SearchResponse
 | `data` | `Array<EmbeddingObject>` | — | Data |
 | `model` | `string` | — | Model |
 | `usage` | `Usage | null` | `null` | Usage (usage) |
+
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```typescript
+estimatedCost(): number | null
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `globalLimit` | `number | null` | `null` | Global limit |
+| `modelLimits` | `Record<string, number> | null` | `null` | Model limits |
+| `enforcement` | `string | null` | `null` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `maxEntries` | `number | null` | `null` | Maximum entries |
+| `ttlSeconds` | `number | null` | `null` | Ttl seconds |
+| `backend` | `string | null` | `null` | Backend |
+| `backendConfig` | `Record<string, string> | null` | `null` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### createFile()
+
+Upload a file.
+
+**Signature:**
+
+```typescript
+createFile(req: CreateFileRequest): FileObject
+```
+
+###### retrieveFile()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```typescript
+retrieveFile(fileId: string): FileObject
+```
+
+###### deleteFile()
+
+Delete a file.
+
+**Signature:**
+
+```typescript
+deleteFile(fileId: string): DeleteResponse
+```
+
+###### listFiles()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```typescript
+listFiles(query: FileListQuery): FileListResponse
+```
+
+###### fileContent()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```typescript
+fileContent(fileId: string): Buffer
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `string | null` | `null` | Api key |
+| `baseUrl` | `string | null` | `null` | Base url |
+| `modelHint` | `string | null` | `null` | Model hint |
+| `timeoutSecs` | `number | null` | `null` | Timeout secs |
+| `maxRetries` | `number | null` | `null` | Maximum retries |
+| `extraHeaders` | `Record<string, string> | null` | `null` | Extra headers |
+| `cache` | `FileCacheConfig | null` | `null` | Cache (file cache config) |
+| `budget` | `FileBudgetConfig | null` | `null` | Budget (file budget config) |
+| `cooldownSecs` | `number | null` | `null` | Cooldown secs |
+| `rateLimit` | `FileRateLimitConfig | null` | `null` | Rate limit (file rate limit config) |
+| `healthCheckSecs` | `number | null` | `null` | Health check secs |
+| `costTracking` | `boolean | null` | `null` | Cost tracking |
+| `tracing` | `boolean | null` | `null` | Tracing |
+| `providers` | `Array<FileProviderConfig> | null` | `null` | Providers |
+
+##### Methods
+
+###### fromTomlFile()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```typescript
+static fromTomlFile(path: Path): FileConfig
+```
+
+###### fromTomlStr()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```typescript
+static fromTomlStr(s: string): FileConfig
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```typescript
+static discover(): FileConfig | null
+```
+
+###### intoBuilder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```typescript
+intoBuilder(): ClientConfigBuilder
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```typescript
+providers(): Array<FileProviderConfig>
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | — | The name |
+| `baseUrl` | `string` | — | Base url |
+| `authHeader` | `string | null` | `null` | Auth header |
+| `modelPrefixes` | `Array<string>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `number | null` | `null` | Rpm |
+| `tpm` | `number | null` | `null` | Tpm |
+| `windowSeconds` | `number | null` | `null` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### isTransient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```typescript
+isTransient(): boolean
+```
+
+###### errorType()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```typescript
+errorType(): string
+```
+
+###### fromStatus()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```typescript
+static fromStatus(status: number, body: string, retryAfter: number): LiterLlmError
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```typescript
+chat(req: ChatCompletionRequest): ChatCompletionResponse
+```
+
+###### chatStream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```typescript
+chatStream(req: ChatCompletionRequest): BoxStream
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```typescript
+embed(req: EmbeddingRequest): EmbeddingResponse
+```
+
+###### listModels()
+
+List available models.
+
+**Signature:**
+
+```typescript
+listModels(): ModelsListResponse
+```
+
+###### imageGenerate()
+
+Generate an image.
+
+**Signature:**
+
+```typescript
+imageGenerate(req: CreateImageRequest): ImagesResponse
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```typescript
+speech(req: CreateSpeechRequest): Buffer
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```typescript
+transcribe(req: CreateTranscriptionRequest): TranscriptionResponse
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```typescript
+moderate(req: ModerationRequest): ModerationResponse
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```typescript
+rerank(req: RerankRequest): RerankResponse
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```typescript
+search(req: SearchRequest): SearchResponse
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```typescript
+ocr(req: OcrRequest): OcrResponse
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chatRaw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```typescript
+chatRaw(req: ChatCompletionRequest): RawExchange
+```
+
+###### chatStreamRaw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```typescript
+chatStreamRaw(req: ChatCompletionRequest): RawStreamExchange
+```
+
+###### embedRaw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```typescript
+embedRaw(req: EmbeddingRequest): RawExchange
+```
+
+###### imageGenerateRaw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```typescript
+imageGenerateRaw(req: CreateImageRequest): RawExchange
+```
+
+###### transcribeRaw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```typescript
+transcribeRaw(req: CreateTranscriptionRequest): RawExchange
+```
+
+###### moderateRaw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```typescript
+moderateRaw(req: ModerationRequest): RawExchange
+```
+
+###### rerankRaw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```typescript
+rerankRaw(req: RerankRequest): RawExchange
+```
+
+###### searchRaw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```typescript
+searchRaw(req: SearchRequest): RawExchange
+```
+
+###### ocrRaw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```typescript
+ocrRaw(req: OcrRequest): RawExchange
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```typescript
+static new(config: ClientConfig, modelHint: string): ManagedClient
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```typescript
+inner(): DefaultClient
+```
+
+###### budgetState()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```typescript
+budgetState(): BudgetState | null
+```
+
+###### hasMiddleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```typescript
+hasMiddleware(): boolean
+```
+
+###### chat()
+
+**Signature:**
+
+```typescript
+chat(req: ChatCompletionRequest): ChatCompletionResponse
+```
+
+###### chatStream()
+
+**Signature:**
+
+```typescript
+chatStream(req: ChatCompletionRequest): BoxStream
+```
+
+###### embed()
+
+**Signature:**
+
+```typescript
+embed(req: EmbeddingRequest): EmbeddingResponse
+```
+
+###### listModels()
+
+**Signature:**
+
+```typescript
+listModels(): ModelsListResponse
+```
+
+###### imageGenerate()
+
+**Signature:**
+
+```typescript
+imageGenerate(req: CreateImageRequest): ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```typescript
+speech(req: CreateSpeechRequest): Buffer
+```
+
+###### transcribe()
+
+**Signature:**
+
+```typescript
+transcribe(req: CreateTranscriptionRequest): TranscriptionResponse
+```
+
+###### moderate()
+
+**Signature:**
+
+```typescript
+moderate(req: ModerationRequest): ModerationResponse
+```
+
+###### rerank()
+
+**Signature:**
+
+```typescript
+rerank(req: RerankRequest): RerankResponse
+```
+
+###### search()
+
+**Signature:**
+
+```typescript
+search(req: SearchRequest): SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```typescript
+ocr(req: OcrRequest): OcrResponse
+```
+
+###### createFile()
+
+**Signature:**
+
+```typescript
+createFile(req: CreateFileRequest): FileObject
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```typescript
+retrieveFile(fileId: string): FileObject
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```typescript
+deleteFile(fileId: string): DeleteResponse
+```
+
+###### listFiles()
+
+**Signature:**
+
+```typescript
+listFiles(query: FileListQuery): FileListResponse
+```
+
+###### fileContent()
+
+**Signature:**
+
+```typescript
+fileContent(fileId: string): Buffer
+```
+
+###### createBatch()
+
+**Signature:**
+
+```typescript
+createBatch(req: CreateBatchRequest): BatchObject
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```typescript
+retrieveBatch(batchId: string): BatchObject
+```
+
+###### listBatches()
+
+**Signature:**
+
+```typescript
+listBatches(query: BatchListQuery): BatchListResponse
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```typescript
+cancelBatch(batchId: string): BatchObject
+```
+
+###### createResponse()
+
+**Signature:**
+
+```typescript
+createResponse(req: CreateResponseRequest): ResponseObject
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```typescript
+retrieveResponse(id: string): ResponseObject
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```typescript
+cancelResponse(id: string): ResponseObject
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `string` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `OcrDocument` | — | The document to process. |
-| `pages` | `Array<number> | null` | `null` | Specific pages to process (1-indexed). `null` means all pages. |
+| `pages` | `Array<number> | null` | `null` | Specific pages to process (1-indexed). `None` means all pages. |
 | `includeImageBase64` | `boolean | null` | `null` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `string` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### createResponse()
+
+Create a new response.
+
+**Signature:**
+
+```typescript
+createResponse(req: CreateResponseRequest): ResponseObject
+```
+
+###### retrieveResponse()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```typescript
+retrieveResponse(id: string): ResponseObject
+```
+
+###### cancelResponse()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```typescript
+cancelResponse(id: string): ResponseObject
+```
 
 
 ---
@@ -1189,3 +2573,4 @@ Errors are thrown as plain `Error` objects with descriptive messages.
 
 
 ---
+

--- a/docs/reference/api-wasm.md
+++ b/docs/reference/api-wasm.md
@@ -135,6 +135,20 @@ function unregisterCustomProvider(name: string): boolean
 
 ### Types
 
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `string` | — | Message |
+| `errorType` | `string` | — | Error type |
+| `param` | `string | null` | `null` | Param |
+| `code` | `string | null` | `null` | Code |
+
+
+---
+
 #### AssistantMessage
 
 | Field | Type | Default | Description |
@@ -154,6 +168,55 @@ function unregisterCustomProvider(name: string): boolean
 |-------|------|---------|-------------|
 | `data` | `string` | — | Base64-encoded audio data. |
 | `format` | `string` | — | Audio format (e.g., "wav", "mp3", "ogg"). |
+
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+##### Methods
+
+###### createBatch()
+
+Create a new batch job.
+
+**Signature:**
+
+```typescript
+createBatch(req: CreateBatchRequest): BatchObject
+```
+
+###### retrieveBatch()
+
+Retrieve a batch by ID.
+
+**Signature:**
+
+```typescript
+retrieveBatch(batchId: string): BatchObject
+```
+
+###### listBatches()
+
+List batches, optionally filtered by query parameters.
+
+**Signature:**
+
+```typescript
+listBatches(query: BatchListQuery): BatchListResponse
+```
+
+###### cancelBatch()
+
+Cancel an in-progress batch.
+
+**Signature:**
+
+```typescript
+cancelBatch(batchId: string): BatchObject
+```
 
 
 ---
@@ -215,6 +278,22 @@ function unregisterCustomProvider(name: string): boolean
 | `systemFingerprint` | `string | null` | `null` | System fingerprint |
 | `serviceTier` | `string | null` | `null` | Service tier |
 
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this response based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+**Signature:**
+
+```typescript
+estimatedCost(): number | null
+```
+
 
 ---
 
@@ -235,6 +314,290 @@ function unregisterCustomProvider(name: string): boolean
 | `index` | `number` | — | Index |
 | `message` | `AssistantMessage` | — | Message (assistant message) |
 | `finishReason` | `FinishReason | null` | `null` | Finish reason (finish reason) |
+
+
+---
+
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `string` | — | API key for authentication (stored as a secret). |
+| `baseUrl` | `string | null` | `null` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `number` | — | Request timeout. |
+| `maxRetries` | `number` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credentialProvider` | `CredentialProvider | null` | `null` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `loadEnv` | `boolean` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+##### Methods
+
+###### headers()
+
+Return the extra headers as an ordered slice of `(name, value)` pairs.
+
+**Signature:**
+
+```typescript
+headers(): Array<[string, string]>
+```
+
+###### fmt()
+
+**Signature:**
+
+```typescript
+fmt(f: Formatter): Unknown
+```
+
+
+---
+
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+##### Methods
+
+###### fromEnv()
+
+Create a builder with no explicit API key.
+
+`load_env` is `true` by default, so the key will be read from the
+provider's environment variable (e.g. `OPENAI_API_KEY`) at client
+construction time.  Call `.load_env(false)` to opt out.
+
+**Signature:**
+
+```typescript
+static fromEnv(): ClientConfigBuilder
+```
+
+###### loadEnv()
+
+Enable or disable automatic API key loading from environment variables.
+
+When `true` (the default) and no explicit `api_key` was provided,
+`DefaultClient.new` reads the provider's designated environment
+variable.  Set to `false` to require an explicit key.
+
+Has no effect on WASM targets.
+
+**Signature:**
+
+```typescript
+loadEnv(enabled: boolean): ClientConfigBuilder
+```
+
+###### baseUrl()
+
+Override the provider base URL for all requests.
+
+**Signature:**
+
+```typescript
+baseUrl(url: string): ClientConfigBuilder
+```
+
+###### timeout()
+
+Set the per-request timeout (default: 60 s).
+
+**Signature:**
+
+```typescript
+timeout(timeout: number): ClientConfigBuilder
+```
+
+###### maxRetries()
+
+Set the maximum number of retries on 429 / 5xx responses (default: 3).
+
+**Signature:**
+
+```typescript
+maxRetries(retries: number): ClientConfigBuilder
+```
+
+###### credentialProvider()
+
+Set a dynamic credential provider for token-based or refreshable auth.
+
+When configured, the client calls `resolve()` before each request
+instead of using the static `api_key` for authentication.
+
+**Signature:**
+
+```typescript
+credentialProvider(provider: CredentialProvider): ClientConfigBuilder
+```
+
+###### header()
+
+Add a custom header sent on every request.
+
+Returns an error if either `key` or `value` is not a valid HTTP header
+name / value.
+
+This method is only available when the `native-http` feature is enabled
+because header validation relies on `reqwest`'s header types.
+
+**Signature:**
+
+```typescript
+header(key: string, value: string): ClientConfigBuilder
+```
+
+###### cache()
+
+Set the response cache configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`CacheLayer`.
+
+**Signature:**
+
+```typescript
+cache(config: CacheConfig): ClientConfigBuilder
+```
+
+###### cacheStore()
+
+Set a custom cache store backend for the Tower cache middleware.
+
+When set alongside `cache`, the cache layer will use
+this store instead of the default in-memory LRU.
+
+**Signature:**
+
+```typescript
+cacheStore(store: CacheStore): ClientConfigBuilder
+```
+
+###### budget()
+
+Set the budget enforcement configuration for the Tower middleware stack.
+
+When set, bindings and advanced Rust users can read this from the
+built `ClientConfig` to construct a
+`BudgetLayer`.
+
+**Signature:**
+
+```typescript
+budget(config: BudgetConfig): ClientConfigBuilder
+```
+
+###### hook()
+
+Add a single hook to the Tower hooks middleware stack.
+
+Hooks are invoked sequentially in registration order at request
+lifecycle points (pre-request, post-response, on-error).
+
+**Signature:**
+
+```typescript
+hook(hook: LlmHook): ClientConfigBuilder
+```
+
+###### hooks()
+
+Set the full list of hooks for the Tower hooks middleware stack,
+replacing any previously registered hooks.
+
+Hooks are invoked sequentially in registration order.
+
+**Signature:**
+
+```typescript
+hooks(hooks: Array<LlmHook>): ClientConfigBuilder
+```
+
+###### cooldown()
+
+Set the cooldown duration after transient errors.
+
+When set, the client rejects requests with `ServiceUnavailable` for
+the given duration after a transient error (rate limit, timeout,
+server error).
+
+**Signature:**
+
+```typescript
+cooldown(duration: number): ClientConfigBuilder
+```
+
+###### rateLimit()
+
+Set per-model rate limiting configuration.
+
+When set, requests exceeding the configured RPM or TPM limits are
+rejected with `LiterLlmError.RateLimited`.
+
+**Signature:**
+
+```typescript
+rateLimit(config: RateLimitConfig): ClientConfigBuilder
+```
+
+###### healthCheck()
+
+Set the background health check interval.
+
+When set, the client periodically probes the provider and rejects
+requests when the provider is unhealthy.
+
+**Signature:**
+
+```typescript
+healthCheck(interval: number): ClientConfigBuilder
+```
+
+###### costTracking()
+
+Enable or disable per-request cost tracking.
+
+When enabled, estimated USD cost is recorded on the current tracing
+span as `gen_ai.usage.cost`.
+
+**Signature:**
+
+```typescript
+costTracking(enabled: boolean): ClientConfigBuilder
+```
+
+###### tracing()
+
+Enable or disable OpenTelemetry-compatible tracing spans.
+
+When enabled, every request is wrapped in a `gen_ai` tracing span
+with semantic convention attributes.
+
+**Signature:**
+
+```typescript
+tracing(enabled: boolean): ClientConfigBuilder
+```
+
+###### build()
+
+Consume the builder and return the completed `ClientConfig`.
+
+**Signature:**
+
+```typescript
+build(): ClientConfig
+```
 
 
 ---
@@ -320,6 +683,27 @@ async closures and streaming tasks that must be `'static`.
 
 ##### Methods
 
+###### new()
+
+Build a client.
+
+`model_hint` guides provider auto-detection when no explicit
+`base_url` override is present in the config.  For example, passing
+`Some("groq/llama3-70b")` selects the Groq provider.  Pass `null` to
+default to OpenAI.
+
+**Errors:**
+
+Returns a wrapped `reqwest.Error` if the underlying HTTP client
+cannot be constructed.  Header names and values are pre-validated by
+`ClientConfigBuilder.header`, so they are inserted directly here.
+
+**Signature:**
+
+```typescript
+static new(config: ClientConfig, modelHint: string): DefaultClient
+```
+
 ###### chat()
 
 **Signature:**
@@ -333,7 +717,7 @@ chat(req: ChatCompletionRequest): ChatCompletionResponse
 **Signature:**
 
 ```typescript
-chatStream(req: ChatCompletionRequest): string
+chatStream(req: ChatCompletionRequest): BoxStream
 ```
 
 ###### embed()
@@ -358,6 +742,14 @@ listModels(): ModelsListResponse
 
 ```typescript
 imageGenerate(req: CreateImageRequest): ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```typescript
+speech(req: CreateSpeechRequest): Buffer
 ```
 
 ###### transcribe()
@@ -390,6 +782,182 @@ rerank(req: RerankRequest): RerankResponse
 
 ```typescript
 search(req: SearchRequest): SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```typescript
+ocr(req: OcrRequest): OcrResponse
+```
+
+###### chatRaw()
+
+**Signature:**
+
+```typescript
+chatRaw(req: ChatCompletionRequest): RawExchange
+```
+
+###### chatStreamRaw()
+
+**Signature:**
+
+```typescript
+chatStreamRaw(req: ChatCompletionRequest): RawStreamExchange
+```
+
+###### embedRaw()
+
+**Signature:**
+
+```typescript
+embedRaw(req: EmbeddingRequest): RawExchange
+```
+
+###### imageGenerateRaw()
+
+**Signature:**
+
+```typescript
+imageGenerateRaw(req: CreateImageRequest): RawExchange
+```
+
+###### transcribeRaw()
+
+**Signature:**
+
+```typescript
+transcribeRaw(req: CreateTranscriptionRequest): RawExchange
+```
+
+###### moderateRaw()
+
+**Signature:**
+
+```typescript
+moderateRaw(req: ModerationRequest): RawExchange
+```
+
+###### rerankRaw()
+
+**Signature:**
+
+```typescript
+rerankRaw(req: RerankRequest): RawExchange
+```
+
+###### searchRaw()
+
+**Signature:**
+
+```typescript
+searchRaw(req: SearchRequest): RawExchange
+```
+
+###### ocrRaw()
+
+**Signature:**
+
+```typescript
+ocrRaw(req: OcrRequest): RawExchange
+```
+
+###### createFile()
+
+**Signature:**
+
+```typescript
+createFile(req: CreateFileRequest): FileObject
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```typescript
+retrieveFile(fileId: string): FileObject
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```typescript
+deleteFile(fileId: string): DeleteResponse
+```
+
+###### listFiles()
+
+**Signature:**
+
+```typescript
+listFiles(query: FileListQuery): FileListResponse
+```
+
+###### fileContent()
+
+**Signature:**
+
+```typescript
+fileContent(fileId: string): Buffer
+```
+
+###### createBatch()
+
+**Signature:**
+
+```typescript
+createBatch(req: CreateBatchRequest): BatchObject
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```typescript
+retrieveBatch(batchId: string): BatchObject
+```
+
+###### listBatches()
+
+**Signature:**
+
+```typescript
+listBatches(query: BatchListQuery): BatchListResponse
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```typescript
+cancelBatch(batchId: string): BatchObject
+```
+
+###### createResponse()
+
+**Signature:**
+
+```typescript
+createResponse(req: CreateResponseRequest): ResponseObject
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```typescript
+retrieveResponse(id: string): ResponseObject
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```typescript
+cancelResponse(id: string): ResponseObject
 ```
 
 
@@ -447,6 +1015,247 @@ search(req: SearchRequest): SearchResponse
 | `data` | `Array<EmbeddingObject>` | — | Data |
 | `model` | `string` | — | Model |
 | `usage` | `Usage | null` | `null` | Usage (usage) |
+
+##### Methods
+
+###### estimatedCost()
+
+Estimate the cost of this embedding request based on embedded pricing data.
+
+Returns `null` if:
+- the `model` field is not present in the embedded pricing registry, or
+- the `usage` field is absent from the response.
+
+Embedding models only charge for input tokens; output cost is zero.
+
+**Signature:**
+
+```typescript
+estimatedCost(): number | null
+```
+
+
+---
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `globalLimit` | `number | null` | `null` | Global limit |
+| `modelLimits` | `Record<string, number> | null` | `null` | Model limits |
+| `enforcement` | `string | null` | `null` | Enforcement |
+
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `maxEntries` | `number | null` | `null` | Maximum entries |
+| `ttlSeconds` | `number | null` | `null` | Ttl seconds |
+| `backend` | `string | null` | `null` | Backend |
+| `backendConfig` | `Record<string, string> | null` | `null` | Backend config |
+
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+##### Methods
+
+###### createFile()
+
+Upload a file.
+
+**Signature:**
+
+```typescript
+createFile(req: CreateFileRequest): FileObject
+```
+
+###### retrieveFile()
+
+Retrieve metadata for a file.
+
+**Signature:**
+
+```typescript
+retrieveFile(fileId: string): FileObject
+```
+
+###### deleteFile()
+
+Delete a file.
+
+**Signature:**
+
+```typescript
+deleteFile(fileId: string): DeleteResponse
+```
+
+###### listFiles()
+
+List files, optionally filtered by query parameters.
+
+**Signature:**
+
+```typescript
+listFiles(query: FileListQuery): FileListResponse
+```
+
+###### fileContent()
+
+Retrieve the raw content of a file.
+
+**Signature:**
+
+```typescript
+fileContent(fileId: string): Buffer
+```
+
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `apiKey` | `string | null` | `null` | Api key |
+| `baseUrl` | `string | null` | `null` | Base url |
+| `modelHint` | `string | null` | `null` | Model hint |
+| `timeoutSecs` | `number | null` | `null` | Timeout secs |
+| `maxRetries` | `number | null` | `null` | Maximum retries |
+| `extraHeaders` | `Record<string, string> | null` | `null` | Extra headers |
+| `cache` | `FileCacheConfig | null` | `null` | Cache (file cache config) |
+| `budget` | `FileBudgetConfig | null` | `null` | Budget (file budget config) |
+| `cooldownSecs` | `number | null` | `null` | Cooldown secs |
+| `rateLimit` | `FileRateLimitConfig | null` | `null` | Rate limit (file rate limit config) |
+| `healthCheckSecs` | `number | null` | `null` | Health check secs |
+| `costTracking` | `boolean | null` | `null` | Cost tracking |
+| `tracing` | `boolean | null` | `null` | Tracing |
+| `providers` | `Array<FileProviderConfig> | null` | `null` | Providers |
+
+##### Methods
+
+###### fromTomlFile()
+
+Load from a TOML file path.
+
+**Signature:**
+
+```typescript
+static fromTomlFile(path: Path): FileConfig
+```
+
+###### fromTomlStr()
+
+Parse from a TOML string.
+
+**Signature:**
+
+```typescript
+static fromTomlStr(s: string): FileConfig
+```
+
+###### discover()
+
+Discover `liter-llm.toml` by walking from current directory to filesystem root.
+
+Returns `Ok(None)` if no config file is found.
+
+**Signature:**
+
+```typescript
+static discover(): FileConfig | null
+```
+
+###### intoBuilder()
+
+Convert into a `ClientConfigBuilder`,
+applying all fields that are set.
+
+Fields not present in the TOML file use the builder's defaults.
+
+**Signature:**
+
+```typescript
+intoBuilder(): ClientConfigBuilder
+```
+
+###### providers()
+
+Get the custom provider configurations from this file config.
+
+**Signature:**
+
+```typescript
+providers(): Array<FileProviderConfig>
+```
+
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `string` | — | The name |
+| `baseUrl` | `string` | — | Base url |
+| `authHeader` | `string | null` | `null` | Auth header |
+| `modelPrefixes` | `Array<string>` | — | Model prefixes |
+
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `number | null` | `null` | Rpm |
+| `tpm` | `number | null` | `null` | Tpm |
+| `windowSeconds` | `number | null` | `null` | Window seconds |
 
 
 ---
@@ -533,6 +1342,542 @@ Response containing generated images.
 ---
 
 #### LiterLlmError
+
+##### Methods
+
+###### isTransient()
+
+Returns `true` for errors that are worth retrying on a different service
+or deployment (transient failures).
+
+Used by `crate.tower.fallback.FallbackService` and
+`crate.tower.router.Router` to decide whether to route to an
+alternative endpoint.
+
+**Signature:**
+
+```typescript
+isTransient(): boolean
+```
+
+###### errorType()
+
+Return the OpenTelemetry `error.type` string for this error variant.
+
+Used by the tracing middleware to record the `error.type` span attribute
+on failed requests per the GenAI semantic conventions.
+
+**Signature:**
+
+```typescript
+errorType(): string
+```
+
+###### fromStatus()
+
+Create from an HTTP status code, an API error response body, and an
+optional `Retry-After` duration already parsed from the response header.
+
+The `retry_after` value is forwarded into `LiterLlmError.RateLimited`
+so callers can honour the server-requested delay without re-parsing the
+header.
+
+**Signature:**
+
+```typescript
+static fromStatus(status: number, body: string, retryAfter: number): LiterLlmError
+```
+
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+##### Methods
+
+###### chat()
+
+Send a chat completion request.
+
+**Signature:**
+
+```typescript
+chat(req: ChatCompletionRequest): ChatCompletionResponse
+```
+
+###### chatStream()
+
+Send a streaming chat completion request.
+
+**Signature:**
+
+```typescript
+chatStream(req: ChatCompletionRequest): BoxStream
+```
+
+###### embed()
+
+Send an embedding request.
+
+**Signature:**
+
+```typescript
+embed(req: EmbeddingRequest): EmbeddingResponse
+```
+
+###### listModels()
+
+List available models.
+
+**Signature:**
+
+```typescript
+listModels(): ModelsListResponse
+```
+
+###### imageGenerate()
+
+Generate an image.
+
+**Signature:**
+
+```typescript
+imageGenerate(req: CreateImageRequest): ImagesResponse
+```
+
+###### speech()
+
+Generate speech audio from text.
+
+**Signature:**
+
+```typescript
+speech(req: CreateSpeechRequest): Buffer
+```
+
+###### transcribe()
+
+Transcribe audio to text.
+
+**Signature:**
+
+```typescript
+transcribe(req: CreateTranscriptionRequest): TranscriptionResponse
+```
+
+###### moderate()
+
+Check content against moderation policies.
+
+**Signature:**
+
+```typescript
+moderate(req: ModerationRequest): ModerationResponse
+```
+
+###### rerank()
+
+Rerank documents by relevance to a query.
+
+**Signature:**
+
+```typescript
+rerank(req: RerankRequest): RerankResponse
+```
+
+###### search()
+
+Perform a web/document search.
+
+**Signature:**
+
+```typescript
+search(req: SearchRequest): SearchResponse
+```
+
+###### ocr()
+
+Extract text from a document via OCR.
+
+**Signature:**
+
+```typescript
+ocr(req: OcrRequest): OcrResponse
+```
+
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+##### Methods
+
+###### chatRaw()
+
+Send a chat completion request and return the raw exchange.
+
+The `raw_request` field contains the final JSON body sent to the
+provider; `raw_response` contains the provider JSON before
+normalization.
+
+**Signature:**
+
+```typescript
+chatRaw(req: ChatCompletionRequest): RawExchange
+```
+
+###### chatStreamRaw()
+
+Send a streaming chat completion request and return the raw exchange.
+
+Only `raw_request` is available upfront — the stream itself is
+returned in `stream` and consumed incrementally.
+
+**Signature:**
+
+```typescript
+chatStreamRaw(req: ChatCompletionRequest): RawStreamExchange
+```
+
+###### embedRaw()
+
+Send an embedding request and return the raw exchange.
+
+**Signature:**
+
+```typescript
+embedRaw(req: EmbeddingRequest): RawExchange
+```
+
+###### imageGenerateRaw()
+
+Generate an image and return the raw exchange.
+
+**Signature:**
+
+```typescript
+imageGenerateRaw(req: CreateImageRequest): RawExchange
+```
+
+###### transcribeRaw()
+
+Transcribe audio to text and return the raw exchange.
+
+**Signature:**
+
+```typescript
+transcribeRaw(req: CreateTranscriptionRequest): RawExchange
+```
+
+###### moderateRaw()
+
+Check content against moderation policies and return the raw exchange.
+
+**Signature:**
+
+```typescript
+moderateRaw(req: ModerationRequest): RawExchange
+```
+
+###### rerankRaw()
+
+Rerank documents by relevance to a query and return the raw exchange.
+
+**Signature:**
+
+```typescript
+rerankRaw(req: RerankRequest): RawExchange
+```
+
+###### searchRaw()
+
+Perform a web/document search and return the raw exchange.
+
+**Signature:**
+
+```typescript
+searchRaw(req: SearchRequest): RawExchange
+```
+
+###### ocrRaw()
+
+Extract text from a document via OCR and return the raw exchange.
+
+**Signature:**
+
+```typescript
+ocrRaw(req: OcrRequest): RawExchange
+```
+
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+##### Methods
+
+###### new()
+
+Build a managed client.
+
+`model_hint` guides provider auto-detection — see
+`DefaultClient.new` for details.
+
+If the config contains any middleware settings (cache, budget, hooks,
+cooldown, rate limit, health check, cost tracking, tracing) the
+corresponding Tower layers are composed into a service stack.
+Otherwise requests pass straight through to the inner client.
+
+**Errors:**
+
+Returns an error if the underlying `DefaultClient` cannot be
+constructed (e.g. invalid headers or HTTP client build failure).
+
+**Signature:**
+
+```typescript
+static new(config: ClientConfig, modelHint: string): ManagedClient
+```
+
+###### inner()
+
+Return a reference to the underlying `DefaultClient`.
+
+**Signature:**
+
+```typescript
+inner(): DefaultClient
+```
+
+###### budgetState()
+
+Return the budget state handle, if budget middleware is configured.
+
+Use this to query accumulated spend at runtime.
+
+**Signature:**
+
+```typescript
+budgetState(): BudgetState | null
+```
+
+###### hasMiddleware()
+
+Return `true` when middleware is active (requests go through the Tower
+service stack).
+
+**Signature:**
+
+```typescript
+hasMiddleware(): boolean
+```
+
+###### chat()
+
+**Signature:**
+
+```typescript
+chat(req: ChatCompletionRequest): ChatCompletionResponse
+```
+
+###### chatStream()
+
+**Signature:**
+
+```typescript
+chatStream(req: ChatCompletionRequest): BoxStream
+```
+
+###### embed()
+
+**Signature:**
+
+```typescript
+embed(req: EmbeddingRequest): EmbeddingResponse
+```
+
+###### listModels()
+
+**Signature:**
+
+```typescript
+listModels(): ModelsListResponse
+```
+
+###### imageGenerate()
+
+**Signature:**
+
+```typescript
+imageGenerate(req: CreateImageRequest): ImagesResponse
+```
+
+###### speech()
+
+**Signature:**
+
+```typescript
+speech(req: CreateSpeechRequest): Buffer
+```
+
+###### transcribe()
+
+**Signature:**
+
+```typescript
+transcribe(req: CreateTranscriptionRequest): TranscriptionResponse
+```
+
+###### moderate()
+
+**Signature:**
+
+```typescript
+moderate(req: ModerationRequest): ModerationResponse
+```
+
+###### rerank()
+
+**Signature:**
+
+```typescript
+rerank(req: RerankRequest): RerankResponse
+```
+
+###### search()
+
+**Signature:**
+
+```typescript
+search(req: SearchRequest): SearchResponse
+```
+
+###### ocr()
+
+**Signature:**
+
+```typescript
+ocr(req: OcrRequest): OcrResponse
+```
+
+###### createFile()
+
+**Signature:**
+
+```typescript
+createFile(req: CreateFileRequest): FileObject
+```
+
+###### retrieveFile()
+
+**Signature:**
+
+```typescript
+retrieveFile(fileId: string): FileObject
+```
+
+###### deleteFile()
+
+**Signature:**
+
+```typescript
+deleteFile(fileId: string): DeleteResponse
+```
+
+###### listFiles()
+
+**Signature:**
+
+```typescript
+listFiles(query: FileListQuery): FileListResponse
+```
+
+###### fileContent()
+
+**Signature:**
+
+```typescript
+fileContent(fileId: string): Buffer
+```
+
+###### createBatch()
+
+**Signature:**
+
+```typescript
+createBatch(req: CreateBatchRequest): BatchObject
+```
+
+###### retrieveBatch()
+
+**Signature:**
+
+```typescript
+retrieveBatch(batchId: string): BatchObject
+```
+
+###### listBatches()
+
+**Signature:**
+
+```typescript
+listBatches(query: BatchListQuery): BatchListResponse
+```
+
+###### cancelBatch()
+
+**Signature:**
+
+```typescript
+cancelBatch(batchId: string): BatchObject
+```
+
+###### createResponse()
+
+**Signature:**
+
+```typescript
+createResponse(req: CreateResponseRequest): ResponseObject
+```
+
+###### retrieveResponse()
+
+**Signature:**
+
+```typescript
+retrieveResponse(id: string): ResponseObject
+```
+
+###### cancelResponse()
+
+**Signature:**
+
+```typescript
+cancelResponse(id: string): ResponseObject
+```
 
 
 ---
@@ -673,7 +2018,7 @@ An OCR request.
 |-------|------|---------|-------------|
 | `model` | `string` | — | The model/provider to use (e.g. `"mistral/mistral-ocr-latest"`). |
 | `document` | `OcrDocument` | — | The document to process. |
-| `pages` | `Array<number> | null` | `null` | Specific pages to process (1-indexed). `null` means all pages. |
+| `pages` | `Array<number> | null` | `null` | Specific pages to process (1-indexed). `None` means all pages. |
 | `includeImageBase64` | `boolean | null` | `null` | Whether to include base64-encoded images of each page. |
 
 
@@ -752,6 +2097,45 @@ The text content of a reranked document, returned when `return_documents` is tru
 | Field | Type | Default | Description |
 |-------|------|---------|-------------|
 | `text` | `string` | — | Text |
+
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+##### Methods
+
+###### createResponse()
+
+Create a new response.
+
+**Signature:**
+
+```typescript
+createResponse(req: CreateResponseRequest): ResponseObject
+```
+
+###### retrieveResponse()
+
+Retrieve a response by ID.
+
+**Signature:**
+
+```typescript
+retrieveResponse(id: string): ResponseObject
+```
+
+###### cancelResponse()
+
+Cancel an in-progress response.
+
+**Signature:**
+
+```typescript
+cancelResponse(id: string): ResponseObject
+```
 
 
 ---
@@ -1189,3 +2573,4 @@ Errors are thrown as plain `Error` objects with descriptive messages.
 
 
 ---
+

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -116,7 +116,7 @@ Deprecated legacy function-role message body.
 |-------|------|---------|-------------|
 | `name` | `str` | — | The name |
 | `description` | `str | None` | `None` | Human-readable description |
-| `schema` | `dict[str, Any]` | — | Schema |
+| `schema` | `Any` | — | Schema |
 | `strict` | `bool | None` | `None` | Strict |
 
 ---
@@ -154,7 +154,7 @@ Deprecated legacy function-role message body.
 | `stream_options` | `StreamOptions | None` | `None` | Stream options (stream options) |
 | `seed` | `int | None` | `None` | Seed |
 | `reasoning_effort` | `ReasoningEffort | None` | `None` | Reasoning effort (reasoning effort) |
-| `extra_body` | `dict[str, Any] | None` | `None` | Provider-specific extra parameters merged into the request body. Use for guardrails, safety settings, grounding config, etc. |
+| `extra_body` | `Any | None` | `None` | Provider-specific extra parameters merged into the request body. Use for guardrails, safety settings, grounding config, etc. |
 
 ---
 
@@ -377,6 +377,115 @@ A search request.
 
 ---
 
+### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `str` | — | API key for authentication (stored as a secret). |
+| `base_url` | `str | None` | `None` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `float` | — | Request timeout. |
+| `max_retries` | `int` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `CredentialProvider | None` | `None` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+---
+
+### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `str | None` | `None` | Api key |
+| `base_url` | `str | None` | `None` | Base url |
+| `model_hint` | `str | None` | `None` | Model hint |
+| `timeout_secs` | `int | None` | `None` | Timeout secs |
+| `max_retries` | `int | None` | `None` | Maximum retries |
+| `extra_headers` | `dict[str, str] | None` | `None` | Extra headers |
+| `cache` | `FileCacheConfig | None` | `None` | Cache (file cache config) |
+| `budget` | `FileBudgetConfig | None` | `None` | Budget (file budget config) |
+| `cooldown_secs` | `int | None` | `None` | Cooldown secs |
+| `rate_limit` | `FileRateLimitConfig | None` | `None` | Rate limit (file rate limit config) |
+| `health_check_secs` | `int | None` | `None` | Health check secs |
+| `cost_tracking` | `bool | None` | `None` | Cost tracking |
+| `tracing` | `bool | None` | `None` | Tracing |
+| `providers` | `list[FileProviderConfig] | None` | `None` | Providers |
+
+---
+
+### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `int | None` | `None` | Maximum entries |
+| `ttl_seconds` | `int | None` | `None` | Ttl seconds |
+| `backend` | `str | None` | `None` | Backend |
+| `backend_config` | `dict[str, str] | None` | `None` | Backend config |
+
+---
+
+### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `float | None` | `None` | Global limit |
+| `model_limits` | `dict[str, float] | None` | `None` | Model limits |
+| `enforcement` | `str | None` | `None` | Enforcement |
+
+---
+
+### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `int | None` | `None` | Rpm |
+| `tpm` | `int | None` | `None` | Tpm |
+| `window_seconds` | `int | None` | `None` | Window seconds |
+
+---
+
+### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `str` | — | The name |
+| `base_url` | `str` | — | Base url |
+| `auth_header` | `str | None` | `None` | Auth header |
+| `model_prefixes` | `list[str]` | — | Model prefixes |
+
+---
+
 ### CustomProviderConfig
 
 Configuration for registering a custom LLM provider at runtime.
@@ -389,3 +498,4 @@ Configuration for registering a custom LLM provider at runtime.
 | `model_prefixes` | `list[str]` | — | Model name prefixes that route to this provider (e.g., ["my-"]). |
 
 ---
+

--- a/docs/reference/errors.md
+++ b/docs/reference/errors.md
@@ -30,3 +30,4 @@ All errors that can occur when using `liter-llm`.
 | `InternalError` | internal error: {message} | An internal logic error (e.g. unexpected Tower response variant). This should never surface in normal operation — if it does, it indicates a bug in the library. |
 
 ---
+

--- a/docs/reference/types.md
+++ b/docs/reference/types.md
@@ -430,6 +430,115 @@ A search request.
 
 ---
 
+#### ClientConfig
+
+Configuration for an LLM client.
+
+`api_key` is stored as a `SecretString` so it is zeroed on drop and never
+printed accidentally.  Access it via `secrecy.ExposeSecret`.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `String` | — | API key for authentication (stored as a secret). |
+| `base_url` | `Option<String>` | `None` | Override base URL.  When set, all requests go here regardless of model name, and provider auto-detection is skipped. |
+| `timeout` | `Duration` | — | Request timeout. |
+| `max_retries` | `u32` | — | Maximum number of retries on 429 / 5xx responses. |
+| `credential_provider` | `Option<CredentialProvider>` | `None` | Optional dynamic credential provider for token-based auth (Azure AD, Vertex OAuth2) or refreshable credentials (AWS STS). When set, the client calls `resolve()` before each request to obtain a fresh credential.  When `None`, the static `api_key` is used. |
+| `load_env` | `bool` | — | Automatically load the API key from the provider's environment variable when no explicit key is provided. When `True` (the default) and `api_key` is empty, `DefaultClient.new` reads the provider's designated environment variable (e.g. `OPENAI_API_KEY` for OpenAI).  Set to `False` to suppress this behaviour and require the caller to supply the key explicitly. Has no effect on WASM targets, where `std.env.var` is unavailable. |
+
+---
+
+#### FileConfig
+
+TOML file representation of client configuration.
+
+All fields are optional — missing fields use defaults from `ClientConfigBuilder`.
+Convert to a builder via `FileConfig.into_builder`.
+
+# Example `liter-llm.toml`
+
+```toml
+api_key = "sk-..."
+base_url = "<https://api.openai.com/v1">
+timeout_secs = 120
+max_retries = 5
+
+[cache]
+max_entries = 512
+ttl_seconds = 600
+backend = "memory"
+
+[budget]
+global_limit = 50.0
+enforcement = "hard"
+
+[[providers]]
+name = "my-provider"
+base_url = "<https://my-llm.example.com/v1">
+model_prefixes = ["my-provider/"]
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `api_key` | `Option<String>` | `None` | Api key |
+| `base_url` | `Option<String>` | `None` | Base url |
+| `model_hint` | `Option<String>` | `None` | Model hint |
+| `timeout_secs` | `Option<u64>` | `None` | Timeout secs |
+| `max_retries` | `Option<u32>` | `None` | Maximum retries |
+| `extra_headers` | `HashMap<String, String>` | `None` | Extra headers |
+| `cache` | `Option<FileCacheConfig>` | `None` | Cache (file cache config) |
+| `budget` | `Option<FileBudgetConfig>` | `None` | Budget (file budget config) |
+| `cooldown_secs` | `Option<u64>` | `None` | Cooldown secs |
+| `rate_limit` | `Option<FileRateLimitConfig>` | `None` | Rate limit (file rate limit config) |
+| `health_check_secs` | `Option<u64>` | `None` | Health check secs |
+| `cost_tracking` | `Option<bool>` | `None` | Cost tracking |
+| `tracing` | `Option<bool>` | `None` | Tracing |
+| `providers` | `Vec<FileProviderConfig>` | `None` | Providers |
+
+---
+
+#### FileCacheConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `max_entries` | `Option<usize>` | `None` | Maximum entries |
+| `ttl_seconds` | `Option<u64>` | `None` | Ttl seconds |
+| `backend` | `Option<String>` | `None` | Backend |
+| `backend_config` | `HashMap<String, String>` | `None` | Backend config |
+
+---
+
+#### FileBudgetConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `global_limit` | `Option<f64>` | `None` | Global limit |
+| `model_limits` | `HashMap<String, f64>` | `None` | Model limits |
+| `enforcement` | `Option<String>` | `None` | Enforcement |
+
+---
+
+#### FileRateLimitConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `rpm` | `Option<u32>` | `None` | Rpm |
+| `tpm` | `Option<u64>` | `None` | Tpm |
+| `window_seconds` | `Option<u64>` | `None` | Window seconds |
+
+---
+
+#### FileProviderConfig
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `name` | `String` | — | The name |
+| `base_url` | `String` | — | Base url |
+| `auth_header` | `Option<String>` | `None` | Auth header |
+| `model_prefixes` | `Vec<String>` | — | Model prefixes |
+
+---
+
 #### CustomProviderConfig
 
 Configuration for registering a custom LLM provider at runtime.
@@ -495,6 +604,29 @@ An image extracted from an OCR page.
 ---
 
 ### Other Types
+
+#### ErrorResponse
+
+Error response from an OpenAI-compatible API.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `error` | `ApiError` | — | Error (api error) |
+
+---
+
+#### ApiError
+
+Inner error object.
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `message` | `String` | — | Message |
+| `error_type` | `String` | — | Error type |
+| `param` | `Option<String>` | `None` | Param |
+| `code` | `Option<String>` | `None` | Code |
+
+---
 
 #### LiterLlmError
 
@@ -685,6 +817,83 @@ Page dimensions in pixels.
 
 ---
 
+#### ClientConfigBuilder
+
+Builder for `ClientConfig`.
+
+Construct with `ClientConfigBuilder.new` and call builder methods to
+customise the configuration, then call `ClientConfigBuilder.build` to
+obtain a `ClientConfig`.
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
+#### ManagedClient
+
+A managed LLM client that wraps `DefaultClient` with optional Tower
+middleware (cache, cooldown, rate limiting, health checks, cost tracking,
+budget, hooks, tracing).
+
+Construct via `ManagedClient.new`.  If the provided `ClientConfig`
+contains any middleware configuration the corresponding Tower layers are
+composed into a service stack.  Otherwise requests pass straight through
+to the inner `DefaultClient`.
+
+`ManagedClient` implements `LlmClient` and can be used everywhere a
+`DefaultClient` is expected.
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
+#### LlmClient
+
+Core LLM client trait.
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
+#### LlmClientRaw
+
+Extension of `LlmClient` that returns raw request/response data
+alongside the typed response.
+
+Every `_raw` method mirrors its counterpart on `LlmClient` but wraps the
+result in a `RawExchange` that exposes the final request body (after
+`transform_request`) and the raw provider response (before
+`transform_response`). This is useful for debugging provider-specific
+transformations, capturing wire-level data, or implementing custom parsing.
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
+#### FileClient
+
+File management operations (upload, list, retrieve, delete).
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
+#### BatchClient
+
+Batch processing operations (create, list, retrieve, cancel).
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
+#### ResponseClient
+
+Responses API operations (create, retrieve, cancel).
+
+*Opaque type — fields are not directly accessible.*
+
+---
+
 #### DefaultClient
 
 Default client implementation backed by `reqwest`.
@@ -704,3 +913,4 @@ async closures and streaming tasks that must be `'static`.
 *Opaque type — fields are not directly accessible.*
 
 ---
+

--- a/zensical.toml
+++ b/zensical.toml
@@ -54,6 +54,7 @@ nav = [
     ] },
     { "Providers" = "providers.md" },
     { "Changelog" = "CHANGELOG.md" },
+    { "Test Coverage" = "coverage.md" },
     { "Contributing" = "contributing.md" },
 ]
 


### PR DESCRIPTION
## Situation

The committed `docs/reference/api-*.md` pages and the shared
`reference/{types,errors,configuration}.md` had drifted from the current Rust IR. Several
public surfaces existed in code but were invisible in the rendered docs site — including
`ManagedClient`, the `LlmClientRaw` `_raw` escape-hatch suite, `FileClient` / `BatchClient` /
`ResponseClient` with their methods, the full `ClientConfig` + `ClientConfigBuilder` surface,
the `FileConfig` TOML family, and the `ErrorResponse` / `ApiError` envelope.

## Task

Bring the alef-generated reference docs back in sync with the Rust IR so CI's `alef verify`
and API docs freshness check agree with `main`, and register the pre-existing test-coverage
page in the nav.

## Action

- Ran `alef extract && alef docs` against the current sources, regenerating:
  - `docs/reference/api-{c,csharp,elixir,go,java,php,python,ruby,rust,typescript,wasm}.md`
    (all 11 bindings, roughly doubled in size)
  - `docs/reference/types.md` (+210 lines)
  - `docs/reference/configuration.md` (+114 lines)
  - `docs/reference/errors.md` (+1 line)
- Added a `"Test Coverage" = "coverage.md"` entry to the zensical nav in `zensical.toml`.

## Result

Every language binding now has reference documentation for `ManagedClient`,
`LlmClient` / `LlmClientRaw`, the nine `_raw` methods, `FileClient` / `BatchClient` /
`ResponseClient` with all their methods, the full `ClientConfig` + builder, the
`FileConfig` TOML family, the OpenAI-compatible error envelope, `estimated_cost()`,
and error-introspection methods. Net diff: +17,412 / -1,849 across 15 files.

## Acceptance Criteria

- [ ] `alef verify` passes in CI
- [ ] API docs freshness check passes in CI
- [ ] Linting passes
- [ ] Zensical nav builds without errors
- [ ] Spot-check: `docs/reference/api-python.md` contains `ManagedClient`, `chat_raw`, and `ClientConfigBuilder` sections