### PR TITLE
fix(docs): correct webmanifest name to liter-llm

### DIFF
--- a/docs/assets/site.webmanifest
+++ b/docs/assets/site.webmanifest
@@ -1,6 +1,6 @@
 {
-  "name": "Xberg",
-  "short_name": "Xberg",
+  "name": "liter-llm",
+  "short_name": "liter-llm",
   "icons": [
     {
       "src": "android-chrome-192x192.png",

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -72,7 +72,6 @@
 <link rel="icon" type="image/png" sizes="32x32" href="{{ config.site_url }}assets/favicon-32x32.png" />
 <link rel="manifest" href="{{ config.site_url }}assets/site.webmanifest" />
 
-
 <meta name="twitter:card" content="summary_large_image" />
 <meta
   name="twitter:title"


### PR DESCRIPTION
The webmanifest was left with the placeholder name `"Xberg"` from the initial template commit. Fixes it to `"liter-llm"` to match the site. Also removes a stray double blank line in `docs/overrides/main.html`.