### PR TITLE
Refresh MiniMax regional endpoint metadata

### DIFF
--- a/crates/liter-llm/schemas/providers.json
+++ b/crates/liter-llm/schemas/providers.json
@@ -2383,6 +2383,20 @@
       "name": "minimax",
       "display_name": "Minimax",
       "base_url": "https://api.minimax.io/v1",
+      "regional_endpoints": [
+        {
+          "region": "global_en",
+          "openai_base_url": "https://api.minimax.io/v1",
+          "anthropic_base_url": "https://api.minimax.io/anthropic",
+          "docs_root": "https://platform.minimax.io/docs"
+        },
+        {
+          "region": "cn_zh",
+          "openai_base_url": "https://api.minimaxi.com/v1",
+          "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+          "docs_root": "https://platform.minimaxi.com/docs"
+        }
+      ],
       "auth": {
         "type": "bearer",
         "env_var": "MINIMAX_API_KEY"
@@ -2398,7 +2412,7 @@
       "model_count": 9,
       "capabilities": {
         "vision": true,
-        "reasoning": false,
+        "reasoning": true,
         "structured_output": true,
         "function_calling": true,
         "audio_in": true,

--- a/crates/liter-llm/src/provider/mod.rs
+++ b/crates/liter-llm/src/provider/mod.rs
@@ -126,6 +126,15 @@ fn registry() -> Result<&'static ProviderRegistry> {
     })
 }
 
+#[allow(dead_code)]
+#[derive(Debug, Clone, PartialEq, Eq, Deserialize)]
+struct RegionalEndpointConfig {
+    region: String,
+    openai_base_url: String,
+    anthropic_base_url: String,
+    docs_root: String,
+}
+
 /// Internal JSON shape: each provider entry with capability flags and streaming
 /// format, stored separately from the public [`ProviderConfig`] schema.
 #[derive(Debug, Deserialize)]
@@ -134,6 +143,10 @@ struct ProviderEntry {
     config: ProviderConfig,
     #[serde(default)]
     capabilities: ProviderCapabilities,
+    /// Protocol-specific base URLs available in each supported region.
+    #[allow(dead_code)]
+    #[serde(default)]
+    regional_endpoints: Vec<RegionalEndpointConfig>,
     /// Streaming wire format for this provider.
     ///
     /// Deserialized from `providers.json` and available to future workstreams
@@ -825,6 +838,35 @@ pub fn complex_provider_names() -> Result<&'static HashSet<String>> {
 mod tests {
     use super::*;
     use serde_json::json;
+
+    #[test]
+    fn minimax_regional_endpoints_are_registered() {
+        let registry = registry().expect("registry should load");
+        let provider = registry
+            .providers
+            .iter()
+            .find(|entry| entry.config.name == "minimax")
+            .expect("MiniMax provider should be registered");
+
+        assert!(provider.capabilities.reasoning);
+        assert_eq!(
+            provider.regional_endpoints,
+            vec![
+                RegionalEndpointConfig {
+                    region: "global_en".into(),
+                    openai_base_url: "https://api.minimax.io/v1".into(),
+                    anthropic_base_url: "https://api.minimax.io/anthropic".into(),
+                    docs_root: "https://platform.minimax.io/docs".into(),
+                },
+                RegionalEndpointConfig {
+                    region: "cn_zh".into(),
+                    openai_base_url: "https://api.minimaxi.com/v1".into(),
+                    anthropic_base_url: "https://api.minimaxi.com/anthropic".into(),
+                    docs_root: "https://platform.minimaxi.com/docs".into(),
+                },
+            ]
+        );
+    }
 
     #[test]
     fn transform_response_audio_message_hoisted() {

--- a/schemas/providers.json
+++ b/schemas/providers.json
@@ -2383,6 +2383,20 @@
       "name": "minimax",
       "display_name": "Minimax",
       "base_url": "https://api.minimax.io/v1",
+      "regional_endpoints": [
+        {
+          "region": "global_en",
+          "openai_base_url": "https://api.minimax.io/v1",
+          "anthropic_base_url": "https://api.minimax.io/anthropic",
+          "docs_root": "https://platform.minimax.io/docs"
+        },
+        {
+          "region": "cn_zh",
+          "openai_base_url": "https://api.minimaxi.com/v1",
+          "anthropic_base_url": "https://api.minimaxi.com/anthropic",
+          "docs_root": "https://platform.minimaxi.com/docs"
+        }
+      ],
       "auth": {
         "type": "bearer",
         "env_var": "MINIMAX_API_KEY"
@@ -2398,7 +2412,7 @@
       "model_count": 9,
       "capabilities": {
         "vision": true,
-        "reasoning": false,
+        "reasoning": true,
         "structured_output": true,
         "function_calling": true,
         "audio_in": true,


### PR DESCRIPTION
Reason: The MiniMax registry lacks regional protocol endpoint metadata and reports reasoning as unsupported.

## Related

No linked issue.

## Description

- Add global and CN OpenAI-compatible and Anthropic-compatible base URLs with regional documentation roots.
- Mark reasoning support in the provider capability metadata.
- Parse and test the regional endpoint metadata in the embedded registry.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable

## Checks

- `cargo fmt --all -- --check`
- `cargo test --locked -p liter-llm --lib minimax_regional_endpoints_are_registered`
- `cargo test --locked -p liter-llm --lib capability_tests`
- `cargo clippy --locked -p liter-llm --lib -- -D warnings`
- `uv run --no-sync python scripts/generate_providers_doc.py --validate`
