### PR TITLE
fix: surface mid-stream provider errors instead of a parse failure

### DIFF
--- a/crates/liter-llm/src/provider/mod.rs
+++ b/crates/liter-llm/src/provider/mod.rs
@@ -481,6 +481,35 @@ pub(crate) trait Provider: Send + Sync {
     /// Returns `Ok(None)` to skip this event (continue reading the stream).
     /// Returns `Err` when the event cannot be parsed.
     fn parse_stream_event(&self, event_data: &str) -> Result<Option<crate::types::ChatCompletionChunk>> {
+        // ~keep An OpenAI-compatible provider may accept a stream (HTTP 200,
+        // `text/event-stream`) and then abort mid-stream by sending a `data:`
+        // line carrying an error object — `{"error": {"message": ..., "code":
+        // ..., "status_code": ...}}` — before closing the connection. Groq does
+        // this when a model emits a malformed tool call. The status lives in the
+        // payload, not the response code, so it must be recovered here.
+        //
+        // This check must run BEFORE deserialization: `ChatCompletionChunk`
+        // defaults every field (so providers may omit `id`/`choices`/etc. on
+        // legitimate events — see #155), which means an error object would
+        // otherwise decode into a valid-looking, content-free chunk and the
+        // failure would vanish, leaving callers awaiting content that is never
+        // sent.
+        if let Ok(value) = serde_json::from_str::<serde_json::Value>(event_data)
+            && let Some(error) = value.get("error")
+        {
+            let message = error
+                .get("message")
+                .and_then(serde_json::Value::as_str)
+                .unwrap_or("provider returned an error mid-stream")
+                .to_string();
+            let status = error
+                .get("status_code")
+                .and_then(serde_json::Value::as_u64)
+                .and_then(|s| u16::try_from(s).ok())
+                .unwrap_or(400);
+            return Err(LiterLlmError::BadRequest { message, status });
+        }
+
         serde_json::from_str::<crate::types::ChatCompletionChunk>(event_data)
             .map(Some)
             .map_err(|e| LiterLlmError::Streaming {
@@ -1084,6 +1113,57 @@ mod tests {
             .expect("trailing metadata event must not error")
             .expect("event should decode to a chunk, not be skipped");
         assert!(chunk.id.is_empty());
+        assert!(chunk.choices.is_empty());
+    }
+
+    /// Revert line: delete the `if let Ok(value) = ... && let Some(error) = ...`
+    /// block in `parse_stream_event` to make this test fail.
+    #[test]
+    fn parse_stream_event_surfaces_mid_stream_error_object() {
+        // ~keep Groq answers HTTP 200 + `text/event-stream`, then aborts the
+        // stream with an error object when a model emits a malformed tool call.
+        // The real status lives in the payload, so it must be recovered from
+        // there rather than from the (successful) response code.
+        let payload = r#"{"error":{"message":"tool call validation failed","type":"invalid_request_error","code":"tool_use_failed","status_code":400}}"#;
+        let err = OpenAiProvider
+            .parse_stream_event(payload)
+            .expect_err("a mid-stream error object must not decode as a chunk");
+        assert_eq!(err.status_code(), 400);
+        assert!(
+            err.to_string().contains("tool call validation failed"),
+            "the provider's own message must reach the caller, got: {err}"
+        );
+    }
+
+    /// Revert line: change the `status_code` fallback in `parse_stream_event`
+    /// from `unwrap_or(400)` to `unwrap_or(200)` to make this test fail.
+    #[test]
+    fn parse_stream_event_defaults_status_when_error_object_omits_it() {
+        // ~keep Not every provider includes `status_code` in the error object;
+        // absent one, a 4xx is the safe reading — the request is over and it did
+        // not succeed, so it must not be reported as a 2xx.
+        let payload = r#"{"error":{"message":"upstream capacity exceeded"}}"#;
+        let err = OpenAiProvider
+            .parse_stream_event(payload)
+            .expect_err("an error object without a status must still be an error");
+        assert_eq!(err.status_code(), 400);
+        assert!(err.to_string().contains("upstream capacity exceeded"));
+    }
+
+    /// Revert line: delete `#[serde(default)]` from `ChatCompletionChunk::choices`
+    /// in `types/chat.rs` to make this test fail.
+    #[test]
+    fn parse_stream_event_tolerates_metadata_event_without_choices() {
+        // ~keep The #155 trailing-metadata event omits `id`; a provider may also
+        // omit `choices` entirely on such an event. Defaulting the field keeps
+        // the stream alive, and the error-object guard above runs first so this
+        // tolerance cannot swallow a real failure.
+        let payload =
+            r#"{"object":"chat.completion.chunk","usage":{"prompt_tokens":9,"completion_tokens":1,"total_tokens":10}}"#;
+        let chunk = OpenAiProvider
+            .parse_stream_event(payload)
+            .expect("a metadata event without `choices` must not error")
+            .expect("event should decode to a chunk, not be skipped");
         assert!(chunk.choices.is_empty());
     }
 

--- a/crates/liter-llm/src/types/chat.rs
+++ b/crates/liter-llm/src/types/chat.rs
@@ -331,6 +331,13 @@ pub struct ChatCompletionChunk {
     #[serde(default)]
     pub model: String,
     /// Streaming choices (delta updates).
+    ///
+    // ~keep `#[serde(default)]` for the same reason as the header fields above,
+    // plus one of its own: a provider that aborts mid-stream sends an
+    // error-object event with no `choices` at all (see `parse_stream_event`).
+    // That guard runs before deserialization and returns the provider's real
+    // error, so this default never silently absorbs one.
+    #[serde(default)]
     pub choices: Vec<StreamChoice>,
     /// Token usage (typically only in the final chunk).
     #[serde(default, skip_serializing_if = "Option::is_none")]


### PR DESCRIPTION
## Related

Builds directly on the streaming-tolerance work in #155.

## Description

### The bug

An OpenAI-compatible provider can accept a stream — HTTP 200, `text/event-stream` — and then abort mid-stream by sending a `data:` line carrying an **error object** instead of a chat-completion chunk, before closing the connection:

```json
{"error":{"message":"tool call validation failed","type":"invalid_request_error","code":"tool_use_failed","status_code":400}}
```

Groq does this when a model emits a malformed tool call. Because the HTTP status is already `200`, the real status only exists inside that payload.

On `main` this reaches the caller as:

```
Streaming { message: "failed to parse SSE data: missing field `choices`" }
```

Three things go wrong at once:

1. **It blames the wrong component.** The provider failed, but the error reads as a liter-llm SSE parsing bug. This is a genuinely confusing debugging experience — you go looking for a deserialization defect that isn't there.
2. **The provider's own message is discarded.** `"tool call validation failed"` is the single most useful string in the whole exchange, and it never reaches the caller.
3. **The status code is lost.** `status_code: 400` is right there in the payload; callers get a `Streaming` variant with no status, so a non-retryable request error is indistinguishable from a transport hiccup.

### The fix

Check for the error-object shape *before* deserializing, and return `BadRequest` carrying the provider's real message and status.

### Why the check must come first

This is the part worth reviewing closely, because it's coupled to #155.

#155 defaulted the header fields (`id`, `object`, `created`, `model`) so that OpenCode Zen/Go's trailing metadata event wouldn't abort an otherwise-complete stream. This PR extends the same tolerance to `choices`, for the same reason — a provider may omit it on a metadata event.

But that tolerance has a sharp edge. Once every field defaults, the error payload above **successfully deserializes** into a perfectly valid-looking, entirely content-free chunk. The failure stops being a loud wrong error and becomes a silent one: the stream just ends, and a caller awaiting content waits for something that will never arrive.

So the ordering isn't stylistic. The error guard runs first specifically so that widening `choices` tolerance cannot swallow a real failure. I've noted this in `~keep` comments on both sides so the coupling doesn't get refactored apart later.

### Notes on the details

- `status_code` falls back to `400`, not `200`, when a provider omits it — the request is over and it did not succeed, so it must not be reported as a success.
- The guard only fires on a top-level `error` key, so a normal chunk that happens to contain the word "error" in content is unaffected.
- `u16::try_from` rather than `as`, so an out-of-range status degrades to the `400` fallback instead of silently truncating.

## Checklist

- [x] CI passing
- [x] Tests added where applicable

Three tests, in the house style, each with a `Revert line:` annotation. I verified every annotation by actually performing the stated revert and confirming the named test — and only that test — fails:

| Test | Covers |
|---|---|
| `parse_stream_event_surfaces_mid_stream_error_object` | the Groq payload yields status 400 and the provider's message |
| `parse_stream_event_defaults_status_when_error_object_omits_it` | missing `status_code` falls back to 400, not 200 |
| `parse_stream_event_tolerates_metadata_event_without_choices` | a metadata event without `choices` still parses |

The existing `parse_stream_event_tolerates_trailing_metadata_event_without_id` (#155) continues to pass — I treated it as a regression guard for the `choices` default rather than something to work around.

`cargo clippy --all-features -- -D warnings` and `cargo fmt --check` are both clean. The guard is written as an edition-2024 let-chain per clippy's `collapsible_if`.

---

Per the AI policy in CONTRIBUTING.md: this was written with AI assistance (Claude), reviewed against your conventions, and I've told my user as much. Happy to adjust naming, comment density, or split the `choices` default into its own commit if you'd prefer it separated from the error-guard change.
