### PR TITLE
fix: allow trusted allowlisted hostnames to resolve to private addresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Allow explicitly allowlisted hostnames to resolve to internal addresses while preserving
+  `DenyPrivate` DNS filtering, exact-origin checks, and redirect restrictions. Allowlisting a
+  hostname now trusts its DNS results, including private, loopback, and link-local addresses;
+  literal private IP URLs remain blocked.
+
 ## [2.0.0] - 2026-09-09
 
 ### Breaking changes

--- a/crates/liter-llm/src/provider/outbound_policy.rs
+++ b/crates/liter-llm/src/provider/outbound_policy.rs
@@ -411,11 +411,15 @@ mod resolver_impl {
         host: &str,
         addrs: &[SocketAddr],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        // Every request and redirect is checked against the exact scheme/host/port
-        // allowlist before connecting. Explicitly allowed service hostnames may
-        // resolve to private addresses; DenyPrivate must still reject them here.
-        if !matches!(policy, OutboundPolicy::DenyPrivate) {
-            return Ok(());
+        // DNS only exposes the hostname, so callers must validate the initial
+        // URL's full origin separately. Trust private DNS answers only for an
+        // explicitly listed hostname, including when rechecking cached answers.
+        match policy {
+            OutboundPolicy::Off => return Ok(()),
+            OutboundPolicy::Allowlist(allowed) if allowed.iter().any(|url| url.host_str() == Some(host)) => {
+                return Ok(());
+            }
+            _ => {}
         }
 
         for sa in addrs {
@@ -511,6 +515,12 @@ mod resolver_impl {
             let allowed = resolver
                 .resolve("internal-llm.invalid".parse().expect("DNS name"))
                 .await;
+            set_outbound_policy(OutboundPolicy::Allowlist(vec![
+                Url::parse("http://other-service.invalid:8000").expect("different origin"),
+            ]));
+            let unlisted = resolver
+                .resolve("internal-llm.invalid".parse().expect("DNS name"))
+                .await;
             set_outbound_policy(OutboundPolicy::DenyPrivate);
             let denied = resolver
                 .resolve("internal-llm.invalid".parse().expect("DNS name"))
@@ -520,6 +530,13 @@ mod resolver_impl {
                 allowed.expect("allowlisted cached addresses").collect::<Vec<_>>(),
                 addresses
             );
+            let error = unlisted
+                .err()
+                .expect("Allowlist must recheck cached hostname membership");
+            assert!(matches!(
+                error.downcast_ref::<LiterLlmError>(),
+                Some(LiterLlmError::OutboundForbidden { .. })
+            ));
             let error = denied.err().expect("DenyPrivate must recheck cached addresses");
             assert!(matches!(
                 error.downcast_ref::<LiterLlmError>(),
@@ -539,6 +556,11 @@ pub use resolver_impl::{cached_guarded_resolver, guarded_resolver};
 /// Cross-origin redirects are rejected so credentials in custom headers cannot
 /// be forwarded to a different origin. Active policies also disable proxies;
 /// otherwise the proxy could resolve the target outside the guarded resolver.
+///
+/// Callers must validate each initial request URL with [`validate_outbound_url_sync`]
+/// or [`validate_outbound_url`] before sending it. The DNS resolver sees only the
+/// hostname, not the scheme or port, and literal IP URLs bypass DNS entirely.
+/// These hooks therefore do not enforce the complete initial-origin policy.
 #[cfg_attr(alef, alef(skip))]
 pub fn configure_outbound_client_builder(
     mut builder: reqwest::ClientBuilder,
@@ -908,6 +930,22 @@ mod tests {
 
     #[test]
     #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
+    fn resolver_allowlist_rejects_unlisted_private_addresses() {
+        let policy = OutboundPolicy::Allowlist(vec![Url::parse("http://internal-llm:8000").expect("origin")]);
+        for host in ["other-service", "internal-llm.attacker.invalid", "internal-llm."] {
+            for address in ["172.18.0.2:0", "[fd00::2]:0", "[::1]:0", "169.254.169.254:0"] {
+                let error = resolver_impl::validate_addrs(policy.clone(), host, &[address.parse().expect("address")])
+                    .expect_err("unlisted hostname must not bypass private-address filtering");
+                assert!(matches!(
+                    error.downcast_ref::<LiterLlmError>(),
+                    Some(LiterLlmError::OutboundForbidden { .. })
+                ));
+            }
+        }
+    }
+
+    #[test]
+    #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
     fn resolver_deny_private_still_rejects_private_address() {
         let addrs = [
             "172.18.0.2:8000".parse().expect("private IPv4"),
@@ -946,6 +984,39 @@ mod tests {
             serde_json::json!({})
         );
         assert!(target.finish(), "allowlisted target must receive a request");
+    }
+
+    #[tokio::test]
+    #[serial(outbound_policy)]
+    #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
+    async fn configured_builder_direct_request_checks_private_hostname_membership() {
+        for allow_target in [false, true] {
+            let target = OneShotServer::start("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}".to_string());
+            let target_url = format!("http://localhost:{}/", target.address.port());
+            let allowed_url = if allow_target {
+                target_url.as_str()
+            } else {
+                "http://allowed.invalid:8000"
+            };
+            set_outbound_policy(OutboundPolicy::Allowlist(vec![
+                Url::parse(allowed_url).expect("allowlisted origin"),
+            ]));
+            let client = configure_outbound_client_builder(reqwest::Client::builder(), None)
+                .build()
+                .expect("guarded client");
+            // Exercise the exported builder without the URL-validating request wrapper.
+            let result = client.get(&target_url).send().await;
+            set_outbound_policy(OutboundPolicy::Off);
+            let received = target.finish();
+            if allow_target {
+                assert_eq!(result.expect("allowlisted hostname must be reachable").status(), 200);
+                assert!(received, "allowlisted target must receive a request");
+            } else {
+                let error = LiterLlmError::from(result.expect_err("unlisted localhost must be blocked"));
+                assert!(matches!(error, LiterLlmError::OutboundForbidden { .. }));
+                assert!(!received, "unlisted target must not receive a request");
+            }
+        }
     }
 
     #[tokio::test]

--- a/crates/liter-llm/src/provider/outbound_policy.rs
+++ b/crates/liter-llm/src/provider/outbound_policy.rs
@@ -39,7 +39,11 @@ pub enum OutboundPolicy {
     DenyPrivate,
 
     /// Only allow URLs whose origin (scheme + host + port) matches one of the
-    /// provided entries.
+    /// provided entries. Allowlisted hostnames may resolve to any address,
+    /// including private, loopback, and link-local addresses. Only allowlist
+    /// hostnames whose DNS is trusted: this mode does not prevent an allowed
+    /// hostname from rebinding into a private network. Literal forbidden IP
+    /// addresses remain rejected by URL validation.
     Allowlist(Vec<Url>),
 }
 
@@ -407,7 +411,10 @@ mod resolver_impl {
         host: &str,
         addrs: &[SocketAddr],
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
-        if matches!(policy, OutboundPolicy::Off) {
+        // Every request and redirect is checked against the exact scheme/host/port
+        // allowlist before connecting. Explicitly allowed service hostnames may
+        // resolve to private addresses; DenyPrivate must still reject them here.
+        if !matches!(policy, OutboundPolicy::DenyPrivate) {
             return Ok(());
         }
 
@@ -475,6 +482,50 @@ mod resolver_impl {
     #[cfg_attr(alef, alef(skip))]
     pub fn cached_guarded_resolver(cache_ttl: Option<Duration>) -> Arc<dyn Resolve> {
         Arc::new(CachedGuardedResolver::new(cache_ttl))
+    }
+
+    #[cfg(test)]
+    mod tests {
+        use super::*;
+        use crate::provider::outbound_policy::set_outbound_policy;
+        use serial_test::serial;
+        use url::Url;
+
+        #[tokio::test]
+        #[serial(outbound_policy)]
+        async fn cached_private_addresses_follow_current_policy() {
+            let resolver = CachedGuardedResolver::new(Some(Duration::from_secs(60)));
+            let addresses = vec![
+                "172.18.0.2:0".parse().expect("private IPv4"),
+                "[fd00::2]:0".parse().expect("private IPv6"),
+            ];
+            store_addrs(
+                &resolver.cache,
+                resolver.cache_ttl,
+                "internal-llm.invalid".into(),
+                addresses.clone(),
+            );
+            set_outbound_policy(OutboundPolicy::Allowlist(vec![
+                Url::parse("http://internal-llm.invalid:8000").expect("allowlisted origin"),
+            ]));
+            let allowed = resolver
+                .resolve("internal-llm.invalid".parse().expect("DNS name"))
+                .await;
+            set_outbound_policy(OutboundPolicy::DenyPrivate);
+            let denied = resolver
+                .resolve("internal-llm.invalid".parse().expect("DNS name"))
+                .await;
+            set_outbound_policy(OutboundPolicy::Off);
+            assert_eq!(
+                allowed.expect("allowlisted cached addresses").collect::<Vec<_>>(),
+                addresses
+            );
+            let error = denied.err().expect("DenyPrivate must recheck cached addresses");
+            assert!(matches!(
+                error.downcast_ref::<LiterLlmError>(),
+                Some(LiterLlmError::OutboundForbidden { .. })
+            ));
+        }
     }
 }
 
@@ -825,6 +876,116 @@ mod tests {
                 "catalog redirects must never downgrade transport security"
             );
         });
+    }
+
+    #[test]
+    #[serial(outbound_policy)]
+    #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
+    fn resolver_allowlist_accepts_private_address_after_origin_check() {
+        let origin = Url::parse("http://internal-llm:8000").expect("valid origin");
+        let policy = OutboundPolicy::Allowlist(vec![origin]);
+        with_policy(policy.clone(), || {
+            assert!(validate_outbound_url_sync("http://internal-llm:8000/v1/embeddings").is_ok());
+            for denied in [
+                "http://other-service:8000/v1/embeddings",
+                "http://internal-llm:8001/v1/embeddings",
+                "https://internal-llm:8000/v1/embeddings",
+            ] {
+                assert!(matches!(
+                    validate_outbound_url_sync(denied),
+                    Err(LiterLlmError::OutboundForbidden { .. })
+                ));
+            }
+            let addrs = [
+                "172.18.0.2:8000".parse().expect("private IPv4"),
+                "[fd00::2]:8000".parse().expect("private IPv6"),
+                "[::1]:8000".parse().expect("loopback IPv6"),
+                "[fe80::2]:8000".parse().expect("link-local IPv6"),
+            ];
+            assert!(resolver_impl::validate_addrs(policy, "internal-llm", &addrs).is_ok());
+        });
+    }
+
+    #[test]
+    #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
+    fn resolver_deny_private_still_rejects_private_address() {
+        let addrs = [
+            "172.18.0.2:8000".parse().expect("private IPv4"),
+            "[fd00::2]:8000".parse().expect("private IPv6"),
+            "[::1]:8000".parse().expect("loopback IPv6"),
+            "[fe80::2]:8000".parse().expect("link-local IPv6"),
+        ];
+        for address in addrs {
+            let error = resolver_impl::validate_addrs(OutboundPolicy::DenyPrivate, "private-service", &[address])
+                .expect_err("DenyPrivate must reject private DNS results");
+            assert!(matches!(
+                error.downcast_ref::<LiterLlmError>(),
+                Some(LiterLlmError::OutboundForbidden { .. })
+            ));
+        }
+    }
+
+    #[tokio::test]
+    #[serial(outbound_policy)]
+    #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
+    async fn configured_builder_allows_allowlisted_private_hostname() {
+        let target = OneShotServer::start(
+            "HTTP/1.1 200 OK\r\nContent-Type: application/json\r\nContent-Length: 2\r\n\r\n{}".to_string(),
+        );
+        let target_url = format!("http://localhost:{}/v1/models", target.address.port());
+        set_outbound_policy(OutboundPolicy::Allowlist(vec![
+            Url::parse(&target_url).expect("allowlisted origin"),
+        ]));
+        let client = configure_outbound_client_builder(reqwest::Client::builder(), None)
+            .build()
+            .expect("guarded client");
+        let result = crate::http::request::get_json_raw(&client, &target_url, None, &[], 0).await;
+        set_outbound_policy(OutboundPolicy::Off);
+        assert_eq!(
+            result.expect("allowlisted private hostname must be reachable"),
+            serde_json::json!({})
+        );
+        assert!(target.finish(), "allowlisted target must receive a request");
+    }
+
+    #[tokio::test]
+    #[serial(outbound_policy)]
+    #[cfg(all(feature = "native-http", not(target_arch = "wasm32")))]
+    async fn allowlisted_private_origin_still_rejects_cross_origin_redirect() {
+        let target = OneShotServer::start("HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\n{}".to_string());
+        let target_url = format!("http://localhost:{}/done", target.address.port());
+        let source = OneShotServer::start(format!(
+            "HTTP/1.1 302 Found\r\nLocation: {target_url}\r\nContent-Length: 0\r\n\r\n"
+        ));
+        let source_url = format!("http://localhost:{}/start", source.address.port());
+        set_outbound_policy(OutboundPolicy::Allowlist(vec![
+            Url::parse(&source_url).expect("source origin"),
+            Url::parse(&target_url).expect("target origin"),
+        ]));
+        let client = configure_outbound_client_builder(reqwest::Client::builder(), None)
+            .build()
+            .expect("guarded client");
+        let result = crate::http::request::get_json_raw(&client, &source_url, None, &[], 0).await;
+        set_outbound_policy(OutboundPolicy::Off);
+        assert!(matches!(result, Err(LiterLlmError::OutboundForbidden { .. })));
+        assert!(source.finish(), "allowed private source must receive the request");
+        assert!(!target.finish(), "different-origin target must not receive the request");
+    }
+
+    #[test]
+    #[serial(outbound_policy)]
+    fn allowlist_still_rejects_literal_private_addresses() {
+        for url in ["http://127.0.0.1:8000", "http://[::1]:8000", "http://169.254.169.254"] {
+            with_policy(
+                OutboundPolicy::Allowlist(vec![Url::parse(url).expect("origin")]),
+                || {
+                    assert!(matches!(
+                        validate_outbound_url_sync(url),
+                        Err(LiterLlmError::OutboundForbidden { .. })
+                    ));
+                },
+            );
+        }
     }
 
     #[test]

--- a/docs-site/src/content/docs/server/proxy-configuration.mdx
+++ b/docs-site/src/content/docs/server/proxy-configuration.mdx
@@ -74,6 +74,16 @@ Outbound policy for custom provider and model endpoint URLs. The proxy default i
 | `outbound_policy`    | string       | `"deny_private"` | One of `deny_private`, `allowlist`, or `off`. Use `off` only when every configured endpoint is trusted. |
 | `outbound_allowlist` | `list<string>` | `[]`             | Allowed origins when `outbound_policy = "allowlist"`. Scheme, host, and port define the origin; paths are ignored. |
 
+With `allowlist`, explicitly listed hostnames can resolve to private, loopback, or link-local
+addresses, allowing internal model servers without disabling origin checks. Only list hostnames
+whose DNS you trust: this mode does not block an allowed hostname from resolving or rebinding to
+an internal address. `deny_private` retains its connection-time IP restrictions.
+
+This exception applies to DNS results. Literal private IP URLs remain blocked even when listed.
+Use a trusted service hostname for internal endpoints. Authenticated clients still reject
+cross-origin redirects, including redirects between two allowlisted origins; HTTPS-to-HTTP
+redirects remain blocked.
+
 <Snip_toml_server_security />
 
 ## `[[models]]`


### PR DESCRIPTION
## Description

An explicitly allowlisted origin such as `http://internal-llm:8000` passes the origin check but fails at connection time when DNS returns an RFC1918 address. This prevents internal model endpoints from working with `allowlist` unless outbound policy is disabled entirely.

Apply DNS address restrictions only under `DenyPrivate`. Keep exact scheme/host/port validation and the existing typed `OutboundForbidden` errors. No new configuration field or API variant is introduced.

## Security semantics

This changes the behavior of `Allowlist`: an operator who allowlists a hostname trusts its DNS answers, including private, loopback, and link-local addresses. **An allowlisted hostname can therefore resolve or rebind to an internal address.** The enum documentation, proxy configuration guide, and changelog explicitly state this tradeoff.

`DenyPrivate` remains the proxy default and retains its DNS filtering, including cache hits. Literal forbidden IP URLs remain blocked even if listed; internal endpoints use trusted hostnames. Authenticated clients still reject cross-origin redirects, including between two allowlisted origins, and HTTPS-to-HTTP redirects remain blocked.

## Validation

- Native Linux ARM64, Rust 1.95, locked dependencies: all 38 outbound-policy tests pass.
- Red/green check: removing only the resolver change makes the new private-address regression test fail at the expected assertion; restoring it passes.
- Coverage includes exact-origin denial (host, scheme, port), private IPv4/IPv6 DNS answers, typed `DenyPrivate` errors, cache-hit policy revalidation, a real localhost HTTP request, cross-origin redirects from an allowed private source, and continued rejection of literal private IP URLs.
- `rustfmt` with the repository's Rust 1.95 toolchain and `git diff --check` pass.
- Full cross-language/CI validation is left to upstream CI; no claim that the full project suite was run locally.

## Checklist

- [ ] CI passing
- [x] Tests added where applicable
